### PR TITLE
update request code because it's greater than 16 bits

### DIFF
--- a/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -44,8 +44,8 @@ public class FlutterAppauthPlugin implements MethodCallHandler, PluginRegistry.A
     private static final String AUTHORIZE_ERROR_MESSAGE_FORMAT = "Failed to authorize: [error: %s, description: %s]";
 
     private final Registrar registrar;
-    private final int RC_AUTH_EXCHANGE_CODE = 531984;
-    private final int RC_AUTH = 531985;
+    private final int RC_AUTH_EXCHANGE_CODE = 65030;
+    private final int RC_AUTH = 65031;
     private PendingOperation pendingOperation;
     private String clientSecret;
 


### PR DESCRIPTION
I had a problem when extending from FlutterFragmentActivity instead of FlutterActivity and it's because the requestCode in **startActivityForResult** is greater than 16 bits ( 65535) i changed it to 65030 and 65031.

