### PR TITLE
Bump AppAuth-iOS dependency to fix iOS 13 compatibility

### DIFF
--- a/ios/flutter_appauth.podspec
+++ b/ios/flutter_appauth.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AppAuth', '1.1.0'
+  s.dependency 'AppAuth', '1.2.0'
   s.ios.deployment_target = '8.0'
 end
 


### PR DESCRIPTION
Fixes iOS 13 compatibility

[OIDAuthState.authState fails to show browser on iOS 13](https://github.com/openid/AppAuth-iOS/issues/400)