### PR TITLE
InsecureConnections for Android

### DIFF
--- a/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -153,7 +153,7 @@ public class FlutterAppauthPlugin implements MethodCallHandler, PluginRegistry.A
                 }
             };
             if (tokenRequestParameters.discoveryUrl != null) {
-                AuthorizationServiceConfiguration.fetchFromUrl(Uri.parse(tokenRequestParameters.discoveryUrl), callback);
+                fetchFromUrl(Uri.parse(tokenRequestParameters.discoveryUrl), callback);
             } else {
                 AuthorizationServiceConfiguration.fetchFromIssuer(Uri.parse(tokenRequestParameters.issuer), callback);
 
@@ -174,7 +174,7 @@ public class FlutterAppauthPlugin implements MethodCallHandler, PluginRegistry.A
             performTokenRequest(serviceConfiguration, tokenRequestParameters);
         } else {
             if (tokenRequestParameters.discoveryUrl != null) {
-                AuthorizationServiceConfiguration.fetchFromUrl(Uri.parse(tokenRequestParameters.discoveryUrl), new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
+                AuthorizationServiceConfiguration.RetrieveConfigurationCallback callback = new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
                     @Override
                     public void onFetchConfigurationCompleted(@Nullable AuthorizationServiceConfiguration serviceConfiguration, @Nullable AuthorizationException ex) {
                         if (ex == null) {
@@ -183,7 +183,8 @@ public class FlutterAppauthPlugin implements MethodCallHandler, PluginRegistry.A
                             finishWithDiscoveryError(ex);
                         }
                     }
-                });
+                };
+                fetchFromUrl(Uri.parse(tokenRequestParameters.discoveryUrl), callback);
 
             } else {
 
@@ -345,6 +346,14 @@ public class FlutterAppauthPlugin implements MethodCallHandler, PluginRegistry.A
             }
         } else {
             finishWithError(exchangeCode ? AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE : AUTHORIZE_ERROR_CODE, String.format(AUTHORIZE_ERROR_MESSAGE_FORMAT, authException.error, authException.errorDescription));
+        }
+    }
+
+    private void fetchFromUrl(Uri uri, AuthorizationServiceConfiguration.RetrieveConfigurationCallback callback) {
+        if (allowInsecureConnections) {
+            AuthorizationServiceConfiguration.fetchFromUrl(uri, callback, InsecureConnectionBuilder.INSTANCE);
+        } else {
+            AuthorizationServiceConfiguration.fetchFromUrl(uri, callback);
         }
     }
 


### PR DESCRIPTION
Since I had some [problems](https://github.com/MaikuB/flutter_appauth/issues/12#issuecomment-554936007) while using unencrypted http connections for development purposes, I've found the solution:
The `AuthorizationServiceConfiguration.fetchFromUrl(...)` call need to receive a `ConnectionBuilder` as [third](https://github.com/openid/AppAuth-Android/blob/f1dbeb51f4d905523d804d70363abdb00728d99c/library/java/net/openid/appauth/AuthorizationServiceConfiguration.java#L246) argument.

Furthermore it is necessary to make some changes to your app, in order to allow unencrypted http traffic:
* For [Android](https://stackoverflow.com/a/51902630/3014979) add `android:usesCleartextTraffic="true"` to the `<application` tag in the `AndroidManifest.xml` 
* For [iOS](https://stackoverflow.com/a/40299837/3014979) add the following to the `Info.plist`:
```xml
<key>NSAppTransportSecurity</key>
<dict>
    <key>NSAllowsArbitraryLoads</key>
    <true/>
</dict>
```
