### PR TITLE
[flutter_appauth_platform_interface] Fixes error on casting the tokenAdditionParameters property from calling token method

### DIFF
--- a/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
@@ -62,6 +62,6 @@ class MethodChannelFlutterAppAuth extends FlutterAppAuthPlatform {
                 result['accessTokenExpirationTime'].toInt()),
         result['idToken'],
         result['tokenType'],
-        result['tokenAdditionalParameters']?.cast<String, String>());
+        result['tokenAdditionalParameters']?.cast<String, dynamic>());
   }
 }


### PR DESCRIPTION
Fixes https://github.com/MaikuB/flutter_appauth/issues/86