### PR TITLE
[flutter_appauth][flutter_appauth_platform_interface] Add State as an optional field to AuthorizationTokenRequest

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -145,13 +145,14 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         final String discoveryUrl = (String) arguments.get("discoveryUrl");
         final String redirectUrl = (String) arguments.get("redirectUrl");
         final String loginHint = (String) arguments.get("loginHint");
+        final String state = (String) arguments.get("state");
         clientSecret = (String) arguments.get("clientSecret");
         final ArrayList<String> scopes = (ArrayList<String>) arguments.get("scopes");
         final ArrayList<String> promptValues = (ArrayList<String>) arguments.get("promptValues");
         Map<String, String> serviceConfigurationParameters = (Map<String, String>) arguments.get("serviceConfiguration");
         Map<String, String> additionalParameters = (Map<String, String>) arguments.get("additionalParameters");
         allowInsecureConnections = (boolean) arguments.get("allowInsecureConnections");
-        return new AuthorizationTokenRequestParameters(clientId, issuer, discoveryUrl, scopes, redirectUrl, serviceConfigurationParameters, additionalParameters, loginHint, promptValues);
+        return new AuthorizationTokenRequestParameters(clientId, issuer, discoveryUrl, scopes, redirectUrl, serviceConfigurationParameters, additionalParameters, loginHint, state, promptValues);
     }
 
     @SuppressWarnings("unchecked")
@@ -185,13 +186,13 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         final AuthorizationTokenRequestParameters tokenRequestParameters = processAuthorizationTokenRequestArguments(arguments);
         if (tokenRequestParameters.serviceConfigurationParameters != null) {
             AuthorizationServiceConfiguration serviceConfiguration = requestParametersToServiceConfiguration(tokenRequestParameters);
-            performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues);
+            performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.state, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues);
         } else {
             AuthorizationServiceConfiguration.RetrieveConfigurationCallback callback = new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
                 @Override
                 public void onFetchConfigurationCompleted(@Nullable AuthorizationServiceConfiguration serviceConfiguration, @Nullable AuthorizationException ex) {
                     if (ex == null) {
-                        performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues);
+                        performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.state, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues);
                     } else {
                         finishWithDiscoveryError(ex);
                     }
@@ -260,6 +261,10 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
 
         if (loginHint != null) {
             authRequestBuilder.setLoginHint(loginHint);
+        }
+
+        if (state != null) {
+            authRequestBuilder.setState(state);
         }
 
         if(promptValues != null && !promptValues.isEmpty()) {
@@ -460,11 +465,13 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     private class AuthorizationTokenRequestParameters extends TokenRequestParameters {
         final String loginHint;
         final ArrayList<String> promptValues;
+        final String state;
 
-        private AuthorizationTokenRequestParameters(String clientId, String issuer, String discoveryUrl, ArrayList<String> scopes, String redirectUrl, Map<String, String> serviceConfigurationParameters, Map<String, String> additionalParameters, String loginHint, ArrayList<String> promptValues) {
+        private AuthorizationTokenRequestParameters(String clientId, String issuer, String discoveryUrl, ArrayList<String> scopes, String redirectUrl, Map<String, String> serviceConfigurationParameters, Map<String, String> additionalParameters, String loginHint, ArrayList<String> promptValues, String state) {
             super(clientId, issuer, discoveryUrl, scopes, redirectUrl, null, null, null, null, serviceConfigurationParameters, additionalParameters);
             this.loginHint = loginHint;
             this.promptValues = promptValues;
+            this.state = state;
         }
     }
 

--- a/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
@@ -55,6 +55,7 @@
 @interface AuthorizationTokenRequestParameters : TokenRequestParameters
 @property(nonatomic, strong) NSString *loginHint;
 @property(nonatomic, strong) NSArray *promptValues;
+@property(nonatomic, strong) NSString *state;
 @end
 
 @implementation AuthorizationTokenRequestParameters
@@ -62,6 +63,7 @@
     [super processArguments:arguments];
     _loginHint = [ArgumentProcessor processArgumentValue:arguments withKey:@"loginHint"];
     _promptValues = [ArgumentProcessor processArgumentValue:arguments withKey:@"promptValues"];
+    _state = [ArgumentProcessor processArgumentValue:arguments withKey:@"state"];
     return self;
 }
 @end
@@ -117,6 +119,10 @@ NSString *const AUTHORIZE_ERROR_MESSAGE_FORMAT = @"Failed to authorize: %@";
     if(requestParameters.promptValues) {
         [self ensureAdditionalParametersInitialized:requestParameters];
         [requestParameters.additionalParameters setValue:[requestParameters.promptValues componentsJoinedByString:@","] forKey:@"prompt"];
+    }
+    if(requestParameters.state) {
+        [self ensureAdditionalParametersInitialized:requestParameters];
+        [requestParameters.additionalParameters setValue:requestParameters.state forKey:@"state"];
     }
     if(requestParameters.serviceConfigurationParameters != nil) {
         OIDServiceConfiguration *serviceConfiguration =

--- a/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
@@ -7,11 +7,15 @@ mixin AuthorizationParameters on Mappable {
   /// list of ASCII string values that specifies whether the Authorization Server prompts the End-User for reauthentication and consent
   List<String> promptValues;
 
+  // Used by Authorization Server to verify the login attempt. 
+  String state;
+
   @override
   Map<String, dynamic> toMap() {
     final Map<String, dynamic> map = super.toMap();
     map['loginHint'] = loginHint;
     map['promptValues'] = promptValues;
+    map['state'] = state;
     return map;
   }
 }

--- a/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
@@ -13,6 +13,7 @@ class AuthorizationTokenRequest extends TokenRequest
       AuthorizationServiceConfiguration serviceConfiguration,
       Map<String, String> additionalParameters,
       String issuer,
+      String state,
       String discoveryUrl,
       List<String> promptValues,
       bool allowInsecureConnections = false})
@@ -25,6 +26,7 @@ class AuthorizationTokenRequest extends TokenRequest
             serviceConfiguration: serviceConfiguration,
             additionalParameters: additionalParameters,
             allowInsecureConnections: allowInsecureConnections) {
+    this.state = state;
     this.loginHint = loginHint;
     this.promptValues = promptValues;
   }


### PR DESCRIPTION
Adds State as an optional field. The reason being is Android App-Auth includes a builder for the state parameter and will throw an error when trying to place state in additional parameters