### PR TITLE
Fixes null pointer exceptions when attempting to return a result for …

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -344,13 +344,17 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
 
 
     private void finishWithSuccess(Object data) {
-        pendingOperation.result.success(data);
-        pendingOperation = null;
+        if (pendingOperation != null) {
+            pendingOperation.result.success(data);
+            pendingOperation = null;
+        }
     }
 
     private void finishWithError(String errorCode, String errorMessage) {
-        pendingOperation.result.error(errorCode, errorMessage, null);
-        pendingOperation = null;
+        if (pendingOperation != null) {
+            pendingOperation.result.error(errorCode, errorMessage, null);
+            pendingOperation = null;
+        }
     }
 
     private void finishWithDiscoveryError(AuthorizationException ex) {


### PR DESCRIPTION
…a null pending operation

This situation can occur when too many operations are started at one time. Once one operation completes, there is no longer a pending operation so any operations that complete after will throw a null pointer exception.

As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_appauth])