### PR TITLE
[flutter_appauth] Fix crash when using logout on iOS

### DIFF
--- a/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
@@ -181,9 +181,12 @@ NSString *const AUTHORIZE_ERROR_MESSAGE_FORMAT = @"Failed to authorize: %@";
         _currentAuthorizationFlow = [OIDAuthorizationService presentAuthorizationRequest:request presentingViewController:rootViewController callback:^(OIDAuthorizationResponse *_Nullable authorizationResponse, NSError *_Nullable error) {
             if(authorizationResponse) {
                 NSMutableDictionary *processedResponse = [[NSMutableDictionary alloc] init];
-                [processedResponse setObject:authorizationResponse.additionalParameters forKey:@"authorizationAdditionalParameters"];
-                [processedResponse setObject:authorizationResponse.authorizationCode forKey:@"authorizationCode"];
-                [processedResponse setObject:authorizationResponse.request.codeVerifier forKey:@"codeVerifier"];
+                if(authorizationResponse.additionalParameters)
+                    [processedResponse setObject:authorizationResponse.additionalParameters forKey:@"authorizationAdditionalParameters"];
+                if(authorizationResponse.authorizationCode)
+                    [processedResponse setObject:authorizationResponse.authorizationCode forKey:@"authorizationCode"];
+                if(authorizationResponse.request.codeVerifier)
+                    [processedResponse setObject:authorizationResponse.request.codeVerifier forKey:@"codeVerifier"];
                 result(processedResponse);
             } else {
                 [self finishWithError:AUTHORIZE_ERROR_CODE message:[self formatMessageWithError:AUTHORIZE_ERROR_MESSAGE_FORMAT error:error] result:result];


### PR DESCRIPTION
With flutter appauth, in order to do a logout we need to make an authorize call with the logout endpoint. It works well on Android but crash in iOS when creating the processed response.

This fix will check for the availability of the values before trying to set it in the processed response.