### PR TITLE
[flutter_appauth] Check if intent is null in onActivityResult

### DIFF
--- a/flutter_appauth/CHANGELOG.md
+++ b/flutter_appauth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.2+6
+
+* [Android] community has reported that there seem to be instances where the plugin encounters a null intent on some devices upon processing a authorisation request. This resulted in a crash before but will now throw a `PlatformException`. Thanks to the PR from [Leon Havenga](https://github.com/li0nza)
+
 ## 0.9.2+5
 
 * Updated the Android setup section in the readme to include information for apps targeting Android 11 (API 30) or newer

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -381,6 +381,9 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent intent) {
+        if (intent == null) {
+            return false;
+        }        
         if (pendingOperation == null) {
             return false;
         }

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -48,10 +48,12 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     private static final String AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE = "authorize_and_exchange_code_failed";
     private static final String AUTHORIZE_ERROR_CODE = "authorize_failed";
     private static final String TOKEN_ERROR_CODE = "token_failed";
+    private static final String NULL_INTENT_ERROR_CODE = "null_intent";
 
     private static final String DISCOVERY_ERROR_MESSAGE_FORMAT = "Error retrieving discovery document: [error: %s, description: %s]";
     private static final String TOKEN_ERROR_MESSAGE_FORMAT = "Failed to get token: [error: %s, description: %s]";
     private static final String AUTHORIZE_ERROR_MESSAGE_FORMAT = "Failed to authorize: [error: %s, description: %s]";
+    private static final String NULL_INTENT_ERROR_FORMAT = "Failed to authorize: Null intent received";
 
     private final int RC_AUTH_EXCHANGE_CODE = 65030;
     private final int RC_AUTH = 65031;
@@ -291,7 +293,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                         clientId,
                         ResponseTypeValues.CODE,
                         Uri.parse(redirectUrl));
-        if (scopes != null && !scopes.isEmpty()) {
+        if (scopes != null && !scopes.isEmpty()) {     
             authRequestBuilder.setScopes(scopes);
         }
 
@@ -382,6 +384,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent intent) {
         if (intent == null) {
+            finishWithError(NULL_INTENT_ERROR_CODE, NULL_INTENT_ERROR_FORMAT);
             return false;
         }        
         if (pendingOperation == null) {
@@ -503,4 +506,3 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     }
 
 }
-

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -383,17 +383,17 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent intent) {
-        if (intent == null) {
-            finishWithError(NULL_INTENT_ERROR_CODE, NULL_INTENT_ERROR_FORMAT);
-            return false;
-        }        
         if (pendingOperation == null) {
             return false;
         }
         if (requestCode == RC_AUTH_EXCHANGE_CODE || requestCode == RC_AUTH) {
-            final AuthorizationResponse authResponse = AuthorizationResponse.fromIntent(intent);
-            AuthorizationException ex = AuthorizationException.fromIntent(intent);
-            processAuthorizationData(authResponse, ex, requestCode == RC_AUTH_EXCHANGE_CODE);
+            if (intent == null) {
+                finishWithError(NULL_INTENT_ERROR_CODE, NULL_INTENT_ERROR_FORMAT);
+            } else {
+                final AuthorizationResponse authResponse = AuthorizationResponse.fromIntent(intent);
+                AuthorizationException ex = AuthorizationException.fromIntent(intent);
+                processAuthorizationData(authResponse, ex, requestCode == RC_AUTH_EXCHANGE_CODE);
+            }
             return true;
         }
         return false;

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -293,7 +293,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                         clientId,
                         ResponseTypeValues.CODE,
                         Uri.parse(redirectUrl));
-        if (scopes != null && !scopes.isEmpty()) {     
+        if (scopes != null && !scopes.isEmpty()) {
             authRequestBuilder.setScopes(scopes);
         }
 
@@ -506,3 +506,4 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     }
 
 }
+

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_appauth
 description: This plugin provides an abstraction around the Android and iOS AppAuth SDKs so it can be used to communicate with OAuth 2.0 and OpenID Connect providers
-version: 0.9.2+5
+version: 0.9.2+6
 homepage: https://github.com/MaikuB/flutter_appauth/tree/master/flutter_appauth
 
 environment:


### PR DESCRIPTION
This seems to crash apps when intent is null.

As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_appauth])