### PR TITLE
[flutter_appauth] Reworked identity provider tutorial section, added FusionAuth.

### DIFF
--- a/flutter_appauth/README.md
+++ b/flutter_appauth/README.md
@@ -5,14 +5,14 @@
 
 A Flutter bridge for AppAuth (https://appauth.io) used authenticating and authorizing users. Note that AppAuth also supports the PKCE extension that is required some providers so this plugin should work with them.
 
-Provider tutorials:
-
-* [Auth0](https://auth0.com/blog/get-started-with-flutter-authentication/)
-* [FusionAuth](https://fusionauth.io/blog/2020/11/23/securing-flutter-oauth/)
-
 **IMPORTANT NOTES**:
 - This plugin requires apps to be using AndroidX. The Flutter tooling supports creating apps with AndroidX support but requires passing the `androidx` flag. Details on AndroidX compatibility and migration can be found [here](https://flutter.dev/docs/development/packages-and-plugins/androidx-compatibility)
 - If Chrome Custom Tabs are not working in your Android app, check to make sure that you have the latest version of this plugin, Android Studio, Gradle distribution and Android Gradle plugin for your app. There was previously a known [issue](https://issuetracker.google.com/issues/119183822) with the Android tooling with AndroidX that should now be resolved since Android Studio 3.4 has been released
+
+## Tutorials from identity providers
+
+* [Auth0](https://auth0.com/blog/get-started-with-flutter-authentication/)
+* [FusionAuth](https://fusionauth.io/blog/2020/11/23/securing-flutter-oauth/)
 
 
 ## Getting Started

--- a/flutter_appauth/README.md
+++ b/flutter_appauth/README.md
@@ -5,7 +5,10 @@
 
 A Flutter bridge for AppAuth (https://appauth.io) used authenticating and authorizing users. Note that AppAuth also supports the PKCE extension that is required some providers so this plugin should work with them.
 
-If you're using Auth0, there is a detailed post on the Auth0 blog on how you can use this plugin with Auth0 that you can check out by opening [this link](https://auth0.com/blog/get-started-with-flutter-authentication/).
+Provider tutorials:
+
+* [Auth0](https://auth0.com/blog/get-started-with-flutter-authentication/)
+* [FusionAuth](https://fusionauth.io/blog/2020/11/23/securing-flutter-oauth/)
 
 **IMPORTANT NOTES**:
 - This plugin requires apps to be using AndroidX. The Flutter tooling supports creating apps with AndroidX support but requires passing the `androidx` flag. Details on AndroidX compatibility and migration can be found [here](https://flutter.dev/docs/development/packages-and-plugins/androidx-compatibility)


### PR DESCRIPTION
I added another flutter tutorial which uses appauth_flutter, and reworked it so that other providers can easily add their tutorials.

Full disclosure: I'm an employee of FusionAuth. I didn't write the tutorial, but had a hand in getting it published. If this PR isn't cool to submit, no worries, just thought I'd suggest it.