### PR TITLE
[flutter_appauth] Fix crash when authorizationService has been disposed

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -349,10 +349,12 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
 
         TokenRequest tokenRequest = builder.build();
         AuthorizationService authorizationService = allowInsecureConnections ? insecureAuthorizationService : defaultAuthorizationService;
-        if (clientSecret == null) {
-            authorizationService.performTokenRequest(tokenRequest, tokenResponseCallback);
-        } else {
-            authorizationService.performTokenRequest(tokenRequest, new ClientSecretBasic(clientSecret), tokenResponseCallback);
+        if (authorizationService != null) {
+            if (clientSecret == null) {
+                authorizationService.performTokenRequest(tokenRequest, tokenResponseCallback);
+            } else {
+                authorizationService.performTokenRequest(tokenRequest, new ClientSecretBasic(clientSecret), tokenResponseCallback);
+            }
         }
 
     }


### PR DESCRIPTION
I'm not sure exactly how to fix this issue, but it seems that the `authorizationService` is disposed while the token refresh is still being called. I would've like to call `finishWithError` in this state but not sure what error to pass.

The error occurs in `flutter_appauth: ^0.9.2+6`.

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void net.openid.appauth.AuthorizationService.performTokenRequest(net.openid.appauth.TokenRequest, net.openid.appauth.AuthorizationService$TokenResponseCallback)' on a null object reference
       at io.crossingthestreams.flutterappauth.FlutterAppauthPlugin.performTokenRequest(FlutterAppauthPlugin.java:353)
       at io.crossingthestreams.flutterappauth.FlutterAppauthPlugin.access$500(FlutterAppauthPlugin.java:42)
       at io.crossingthestreams.flutterappauth.FlutterAppauthPlugin$4.onFetchConfigurationCompleted(FlutterAppauthPlugin.java:278)
       at net.openid.appauth.AuthorizationServiceConfiguration$ConfigurationRetrievalAsyncTask.onPostExecute(AuthorizationServiceConfiguration.java:364)
       at net.openid.appauth.AuthorizationServiceConfiguration$ConfigurationRetrievalAsyncTask.onPostExecute(AuthorizationServiceConfiguration.java:305)
       at android.os.AsyncTask.finish(AsyncTask.java:755)
       at android.os.AsyncTask.access$900(AsyncTask.java:192)
       at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:772)
       at android.os.Handler.dispatchMessage(Handler.java:107)
       at android.os.Looper.loop(Looper.java:224)
       at android.app.ActivityThread.main(ActivityThread.java:7590)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:539)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
```