### PR TITLE
[flutter_appauth][flutter_appauth_platform_interface] Add CODE_CHALLENGE_METHOD_PLAIN support to Android

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -15,6 +15,7 @@ import net.openid.appauth.ClientSecretBasic;
 import net.openid.appauth.ResponseTypeValues;
 import net.openid.appauth.TokenRequest;
 import net.openid.appauth.TokenResponse;
+import net.openid.appauth.CodeVerifierUtil;
 
 import net.openid.appauth.connectivity.DefaultConnectionBuilder;
 

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -191,7 +191,8 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         Map<String, String> serviceConfigurationParameters = (Map<String, String>) arguments.get("serviceConfiguration");
         Map<String, String> additionalParameters = (Map<String, String>) arguments.get("additionalParameters");
         allowInsecureConnections = (boolean) arguments.get("allowInsecureConnections");
-        return new AuthorizationTokenRequestParameters(clientId, issuer, discoveryUrl, scopes, redirectUrl, serviceConfigurationParameters, additionalParameters, loginHint, promptValues);
+        final boolean plainCodeVerifierChallengeMethod = (boolean) arguments.get("plainCodeVerifierChallengeMethod");
+        return new AuthorizationTokenRequestParameters(clientId, issuer, discoveryUrl, scopes, redirectUrl, serviceConfigurationParameters, additionalParameters, loginHint, promptValues, plainCodeVerifierChallengeMethod);
     }
 
     @SuppressWarnings("unchecked")
@@ -225,13 +226,13 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         final AuthorizationTokenRequestParameters tokenRequestParameters = processAuthorizationTokenRequestArguments(arguments);
         if (tokenRequestParameters.serviceConfigurationParameters != null) {
             AuthorizationServiceConfiguration serviceConfiguration = requestParametersToServiceConfiguration(tokenRequestParameters);
-            performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues);
+            performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues, tokenRequestParameters.plainCodeVerifierChallengeMethod);
         } else {
             AuthorizationServiceConfiguration.RetrieveConfigurationCallback callback = new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
                 @Override
                 public void onFetchConfigurationCompleted(@Nullable AuthorizationServiceConfiguration serviceConfiguration, @Nullable AuthorizationException ex) {
                     if (ex == null) {
-                        performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues);
+                        performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues, tokenRequestParameters.plainCodeVerifierChallengeMethod);
                     } else {
                         finishWithDiscoveryError(ex);
                     }
@@ -286,7 +287,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     }
 
 
-    private void performAuthorization(AuthorizationServiceConfiguration serviceConfiguration, String clientId, String redirectUrl, ArrayList<String> scopes, String loginHint, Map<String, String> additionalParameters, boolean exchangeCode, ArrayList<String> promptValues) {
+    private void performAuthorization(AuthorizationServiceConfiguration serviceConfiguration, String clientId, String redirectUrl, ArrayList<String> scopes, String loginHint, Map<String, String> additionalParameters, boolean exchangeCode, ArrayList<String> promptValues, boolean plainCodeVerifierChallengeMethod) {
         AuthorizationRequest.Builder authRequestBuilder =
                 new AuthorizationRequest.Builder(
                         serviceConfiguration,
@@ -309,6 +310,10 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
             authRequestBuilder.setAdditionalParameters(additionalParameters);
         }
 
+        if (plainCodeVerifierChallengeMethod) {
+          String codeVerifier = CodeVerifierUtil.generateRandomCodeVerifier();
+          authRequestBuilder.setCodeVerifier(codeVerifier, codeVerifier, "plain");
+        }
 
         AuthorizationService authorizationService = allowInsecureConnections ? insecureAuthorizationService : defaultAuthorizationService;
         Intent authIntent = authorizationService.getAuthorizationRequestIntent(authRequestBuilder.build());
@@ -497,11 +502,13 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     private class AuthorizationTokenRequestParameters extends TokenRequestParameters {
         final String loginHint;
         final ArrayList<String> promptValues;
+        final boolean plainCodeVerifierChallengeMethod;
 
-        private AuthorizationTokenRequestParameters(String clientId, String issuer, String discoveryUrl, ArrayList<String> scopes, String redirectUrl, Map<String, String> serviceConfigurationParameters, Map<String, String> additionalParameters, String loginHint, ArrayList<String> promptValues) {
+        private AuthorizationTokenRequestParameters(String clientId, String issuer, String discoveryUrl, ArrayList<String> scopes, String redirectUrl, Map<String, String> serviceConfigurationParameters, Map<String, String> additionalParameters, String loginHint, ArrayList<String> promptValues, boolean plainCodeVerifierChallengeMethod) {
             super(clientId, issuer, discoveryUrl, scopes, redirectUrl, null, null, null, null, serviceConfigurationParameters, additionalParameters);
             this.loginHint = loginHint;
             this.promptValues = promptValues;
+            this.plainCodeVerifierChallengeMethod = plainCodeVerifierChallengeMethod;
         }
     }
 

--- a/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
@@ -9,4 +9,6 @@ mixin AuthorizationParameters {
   ///
   /// This property is only applicable to iOS versions 13 and above.
   bool? preferEphemeralSession;
+
+  bool? plainCodeVerifierChallengeMethod;
 }

--- a/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
@@ -6,6 +6,7 @@ import 'token_request.dart';
 /// Details required for a combined authorization and code exchange request
 class AuthorizationTokenRequest extends TokenRequest
     with AuthorizationParameters {
+
   AuthorizationTokenRequest(
     String clientId,
     String redirectUrl, {
@@ -19,6 +20,7 @@ class AuthorizationTokenRequest extends TokenRequest
     List<String>? promptValues,
     bool allowInsecureConnections = false,
     bool preferEphemeralSession = false,
+    bool plainCodeVerifierChallengeMethod = false, 
   }) : super(
           clientId,
           redirectUrl,
@@ -34,5 +36,6 @@ class AuthorizationTokenRequest extends TokenRequest
     this.loginHint = loginHint;
     this.promptValues = promptValues;
     this.preferEphemeralSession = preferEphemeralSession;
+    this.plainCodeVerifierChallengeMethod = plainCodeVerifierChallengeMethod;
   }
 }

--- a/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
@@ -81,5 +81,6 @@ Map<String, Object?> _convertAuthorizationParametersToMap(
     'loginHint': authorizationParameters.loginHint,
     'promptValues': authorizationParameters.promptValues,
     'preferEphemeralSession': authorizationParameters.preferEphemeralSession,
+    'plainCodeVerifierChallengeMethod': authorizationParameters..plainCodeVerifierChallengeMethod,
   };
 }


### PR DESCRIPTION
I try to add CODE_CHALLENGE_METHOD_PLAIN support to the wrapper. I only update the Android code.

This pull request is related to #106.