### PR TITLE
[flutter_appauth][flutter_appauth_platform_interface] add responseMode as parameter for android and ios

### DIFF
--- a/flutter_appauth/CHANGELOG.md
+++ b/flutter_appauth/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0
+* Make use of responseMode inside FlutterAppauthPlugin for authorizeAndExchangeCode flow. Was needed otherwise an exception was thrown in the AuthorizationRequest.Builder when setting the responseMode via additionalParameters map.
+
 ## 1.0.0+1
 
 * There are no functional changes in this release. The only changes done were to suppress warnings that were occurring as a result of making use of Android v1 embedding APIs for backwards compatibility

--- a/flutter_appauth/CHANGELOG.md
+++ b/flutter_appauth/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 1.1.0
-* Make use of responseMode inside FlutterAppauthPlugin for authorizeAndExchangeCode flow. Was needed otherwise an exception was thrown in the AuthorizationRequest.Builder when setting the responseMode via additionalParameters map.
+
+* * Added the ability to specify the response mode for authorization requests. This can be done using the `responseMode` parameter  when constructing either an `AuthorizationRequest` or `AuthorizationTokenRequest`. This was done as the AppAuth Android SDK throws an exception when this was done via `additionalParameters`.
 
 ## 1.0.0+1
 

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -285,7 +285,6 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
 
 
     private void performAuthorization(AuthorizationServiceConfiguration serviceConfiguration, String clientId, String redirectUrl, ArrayList<String> scopes, String loginHint, Map<String, String> additionalParameters, boolean exchangeCode, ArrayList<String> promptValues, String responseMode) {
-        System.out.println("START");
         AuthorizationRequest.Builder authRequestBuilder =
                 new AuthorizationRequest.Builder(
                         serviceConfiguration,
@@ -304,7 +303,6 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
             authRequestBuilder.setPromptValues(promptValues);
         }
 
-        System.out.println("responseMode: " + responseMode);
         if (responseMode != null) {
             authRequestBuilder.setResponseMode(responseMode);
         }

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -187,7 +187,9 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         Map<String, String> serviceConfigurationParameters = (Map<String, String>) arguments.get("serviceConfiguration");
         Map<String, String> additionalParameters = (Map<String, String>) arguments.get("additionalParameters");
         allowInsecureConnections = (boolean) arguments.get("allowInsecureConnections");
-        return new AuthorizationTokenRequestParameters(clientId, issuer, discoveryUrl, scopes, redirectUrl, serviceConfigurationParameters, additionalParameters, loginHint, promptValues);
+        final String responseMode = (String) arguments.get("responseMode");
+
+        return new AuthorizationTokenRequestParameters(clientId, issuer, discoveryUrl, scopes, redirectUrl, serviceConfigurationParameters, additionalParameters, loginHint, promptValues, responseMode);
     }
 
     @SuppressWarnings("unchecked")
@@ -221,13 +223,13 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         final AuthorizationTokenRequestParameters tokenRequestParameters = processAuthorizationTokenRequestArguments(arguments);
         if (tokenRequestParameters.serviceConfigurationParameters != null) {
             AuthorizationServiceConfiguration serviceConfiguration = requestParametersToServiceConfiguration(tokenRequestParameters);
-            performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues);
+            performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues, tokenRequestParameters.responseMode);
         } else {
             AuthorizationServiceConfiguration.RetrieveConfigurationCallback callback = new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
                 @Override
                 public void onFetchConfigurationCompleted(@Nullable AuthorizationServiceConfiguration serviceConfiguration, @Nullable AuthorizationException ex) {
                     if (ex == null) {
-                        performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues);
+                        performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues, tokenRequestParameters.responseMode);
                     } else {
                         finishWithDiscoveryError(ex);
                     }
@@ -282,7 +284,8 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     }
 
 
-    private void performAuthorization(AuthorizationServiceConfiguration serviceConfiguration, String clientId, String redirectUrl, ArrayList<String> scopes, String loginHint, Map<String, String> additionalParameters, boolean exchangeCode, ArrayList<String> promptValues) {
+    private void performAuthorization(AuthorizationServiceConfiguration serviceConfiguration, String clientId, String redirectUrl, ArrayList<String> scopes, String loginHint, Map<String, String> additionalParameters, boolean exchangeCode, ArrayList<String> promptValues, String responseMode) {
+        System.out.println("START");
         AuthorizationRequest.Builder authRequestBuilder =
                 new AuthorizationRequest.Builder(
                         serviceConfiguration,
@@ -297,14 +300,18 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
             authRequestBuilder.setLoginHint(loginHint);
         }
 
-        if(promptValues != null && !promptValues.isEmpty()) {
+        if (promptValues != null && !promptValues.isEmpty()) {
             authRequestBuilder.setPromptValues(promptValues);
+        }
+
+        System.out.println("responseMode: " + responseMode);
+        if (responseMode != null) {
+            authRequestBuilder.setResponseMode(responseMode);
         }
 
         if (additionalParameters != null && !additionalParameters.isEmpty()) {
             authRequestBuilder.setAdditionalParameters(additionalParameters);
         }
-
 
         AuthorizationService authorizationService = allowInsecureConnections ? insecureAuthorizationService : defaultAuthorizationService;
         Intent authIntent = authorizationService.getAuthorizationRequestIntent(authRequestBuilder.build());
@@ -493,11 +500,13 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     private class AuthorizationTokenRequestParameters extends TokenRequestParameters {
         final String loginHint;
         final ArrayList<String> promptValues;
+        final String responseMode;
 
-        private AuthorizationTokenRequestParameters(String clientId, String issuer, String discoveryUrl, ArrayList<String> scopes, String redirectUrl, Map<String, String> serviceConfigurationParameters, Map<String, String> additionalParameters, String loginHint, ArrayList<String> promptValues) {
+        private AuthorizationTokenRequestParameters(String clientId, String issuer, String discoveryUrl, ArrayList<String> scopes, String redirectUrl, Map<String, String> serviceConfigurationParameters, Map<String, String> additionalParameters, String loginHint, ArrayList<String> promptValues, String responseMode) {
             super(clientId, issuer, discoveryUrl, scopes, redirectUrl, null, null, null, null, serviceConfigurationParameters, additionalParameters);
             this.loginHint = loginHint;
             this.promptValues = promptValues;
+            this.responseMode = responseMode;
         }
     }
 

--- a/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
@@ -57,6 +57,7 @@
 @interface AuthorizationTokenRequestParameters : TokenRequestParameters
 @property(nonatomic, strong) NSString *loginHint;
 @property(nonatomic, strong) NSArray *promptValues;
+@property(nonatomic, strong) NSString *responseMode;
 @end
 
 @implementation AuthorizationTokenRequestParameters
@@ -64,6 +65,7 @@
     [super processArguments:arguments];
     _loginHint = [ArgumentProcessor processArgumentValue:arguments withKey:@"loginHint"];
     _promptValues = [ArgumentProcessor processArgumentValue:arguments withKey:@"promptValues"];
+    _responseMode = [ArgumentProcessor processArgumentValue:arguments withKey:@"responseMode"];
     return self;
 }
 @end
@@ -119,6 +121,10 @@ NSString *const AUTHORIZE_ERROR_MESSAGE_FORMAT = @"Failed to authorize: %@";
     if(requestParameters.promptValues) {
         [self ensureAdditionalParametersInitialized:requestParameters];
         [requestParameters.additionalParameters setValue:[requestParameters.promptValues componentsJoinedByString:@","] forKey:@"prompt"];
+    }
+    if(requestParameters.responseMode) {
+        [self ensureAdditionalParametersInitialized:requestParameters];
+        [requestParameters.additionalParameters setValue:requestParameters.responseMode forKey:@"response_mode"];
     }
     if(requestParameters.serviceConfigurationParameters != nil) {
         OIDServiceConfiguration *serviceConfiguration =

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_appauth
 description: This plugin provides an abstraction around the Android and iOS AppAuth SDKs so it can be used to communicate with OAuth 2.0 and OpenID Connect providers
-version: 1.0.0+1
+version: 1.1.0
 homepage: https://github.com/MaikuB/flutter_appauth/tree/master/flutter_appauth
 
 environment:

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -10,8 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_appauth_platform_interface:
-    path: ../flutter_appauth_platform_interface
+  flutter_appauth_platform_interface: ^3.0.0
 
 flutter:
   plugin:

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -10,7 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_appauth_platform_interface: ^3.0.0
+  flutter_appauth_platform_interface:
+    path: ../flutter_appauth_platform_interface
 
 flutter:
   plugin:

--- a/flutter_appauth_platform_interface/CHANGELOG.md
+++ b/flutter_appauth_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.0]
+* Add responseMode as parameter
+* responseMode is part of AuthorizationTokenRequest constructor and has not to be added to additionalParameters map. Reason was a validation check on Android side on this map, which does not must include responseMode.
+
 ## [3.0.0]
 
 * Migrated to null safety

--- a/flutter_appauth_platform_interface/CHANGELOG.md
+++ b/flutter_appauth_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [3.1.0]
-* Add responseMode as parameter
-* responseMode is part of AuthorizationTokenRequest constructor and has not to be added to additionalParameters map. Reason was a validation check on Android side on this map, which does not must include responseMode.
+
+* Added the ability to specify the response mode for authorization requests. This can be done using the `responseMode` parameter  when constructing either an `AuthorizationRequest` or `AuthorizationTokenRequest`. This was done as the AppAuth Android SDK throws an exception when this was done via `additionalParameters`.
 
 ## [3.0.0]
 

--- a/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
@@ -9,4 +9,6 @@ mixin AuthorizationParameters {
   ///
   /// This property is only applicable to iOS versions 13 and above.
   bool? preferEphemeralSession;
+
+  String? responseMode;
 }

--- a/flutter_appauth_platform_interface/lib/src/authorization_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_request.dart
@@ -17,6 +17,7 @@ class AuthorizationRequest extends CommonRequestDetails
     List<String>? promptValues,
     bool allowInsecureConnections = false,
     bool preferEphemeralSession = false,
+    String? responseMode,
   }) {
     this.clientId = clientId;
     this.redirectUrl = redirectUrl;
@@ -29,5 +30,6 @@ class AuthorizationRequest extends CommonRequestDetails
     this.promptValues = promptValues;
     this.allowInsecureConnections = allowInsecureConnections;
     this.preferEphemeralSession = preferEphemeralSession;
+    this.responseMode = responseMode;
   }
 }

--- a/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
@@ -19,6 +19,7 @@ class AuthorizationTokenRequest extends TokenRequest
     List<String>? promptValues,
     bool allowInsecureConnections = false,
     bool preferEphemeralSession = false,
+    String? responseMode,
   }) : super(
           clientId,
           redirectUrl,
@@ -34,5 +35,6 @@ class AuthorizationTokenRequest extends TokenRequest
     this.loginHint = loginHint;
     this.promptValues = promptValues;
     this.preferEphemeralSession = preferEphemeralSession;
+    this.responseMode = responseMode;
   }
 }

--- a/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
@@ -81,5 +81,6 @@ Map<String, Object?> _convertAuthorizationParametersToMap(
     'loginHint': authorizationParameters.loginHint,
     'promptValues': authorizationParameters.promptValues,
     'preferEphemeralSession': authorizationParameters.preferEphemeralSession,
+    'responseMode': authorizationParameters.responseMode,
   };
 }

--- a/flutter_appauth_platform_interface/pubspec.yaml
+++ b/flutter_appauth_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_appauth_platform_interface
 description: A common platform interface for the flutter_appauth plugin.
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/MaikuB/flutter_appauth/tree/master/flutter_appauth_platform_interface
 
 environment:

--- a/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
+++ b/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
@@ -23,7 +23,7 @@ void main() {
   test('authorize', () async {
     await flutterAppAuth.authorize(AuthorizationRequest(
         'someClientId', 'someRedirectUrl',
-        discoveryUrl: 'someDiscoveryUrl', loginHint: 'someLoginHint'));
+        discoveryUrl: 'someDiscoveryUrl', loginHint: 'someLoginHint', responseMode: 'fragment'));
     expect(
       log,
       <Matcher>[
@@ -39,6 +39,7 @@ void main() {
           'allowInsecureConnections': false,
           'preferEphemeralSession': false,
           'promptValues': null,
+          'responseMode': 'fragment'
         })
       ],
     );

--- a/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
+++ b/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
@@ -47,7 +47,7 @@ void main() {
   test('authorizeAndExchangeCode', () async {
     await flutterAppAuth.authorizeAndExchangeCode(AuthorizationTokenRequest(
         'someClientId', 'someRedirectUrl',
-        discoveryUrl: 'someDiscoveryUrl', loginHint: 'someLoginHint'));
+        discoveryUrl: 'someDiscoveryUrl', loginHint: 'someLoginHint', responseMode: 'fragment'));
     expect(
       log,
       <Matcher>[
@@ -67,7 +67,8 @@ void main() {
           'refreshToken': null,
           'authorizationCode': null,
           'grantType': 'authorization_code',
-          'codeVerifier': null
+          'codeVerifier': null,
+          'responseMode': 'fragment'
         })
       ],
     );

--- a/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
+++ b/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
@@ -23,7 +23,7 @@ void main() {
   test('authorize', () async {
     await flutterAppAuth.authorize(AuthorizationRequest(
         'someClientId', 'someRedirectUrl',
-        discoveryUrl: 'someDiscoveryUrl', loginHint: 'someLoginHint', responseMode: 'fragment'));
+        discoveryUrl: 'someDiscoveryUrl', loginHint: 'someLoginHint'));
     expect(
       log,
       <Matcher>[
@@ -39,7 +39,7 @@ void main() {
           'allowInsecureConnections': false,
           'preferEphemeralSession': false,
           'promptValues': null,
-          'responseMode': 'fragment'
+          'responseMode': null
         })
       ],
     );


### PR DESCRIPTION
As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_appauth])