### PR TITLE
[flutter_appauth] Skip https issuer check if allowInsecureConnections is true.

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -488,6 +488,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                 AppAuthConfiguration.Builder authConfigBuilder = new AppAuthConfiguration.Builder();
                 if (allowInsecureConnections) {
                     authConfigBuilder.setConnectionBuilder(InsecureConnectionBuilder.INSTANCE);
+                    authConfigBuilder.setSkipIssuerHttpsCheck(true);
                 }
 
                 AuthorizationService authService = new AuthorizationService(applicationContext, authConfigBuilder.build());


### PR DESCRIPTION
Appauth fails to verify the id token and throws an `AuthorizationException` if you try to authorize against an auth service over http even if `allowInsecureConnections` is true. This PR simply sets the `skipIssuerHttpsCheck` flag to true if `allowInsecureConnections` is true.