### PR TITLE
Support ui_locales parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .dart_tool/
 .packages
 .pub/
+.idea/
 build/
 # If you're building an application, you may want to check-in your pubspec.lock
 pubspec.lock

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -307,6 +307,11 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
             authRequestBuilder.setResponseMode(responseMode);
         }
 
+        if(additionalParameters != null && !additionalParameters.isEmpty() && additionalParameters.containsKey("ui_locales")){
+            authRequestBuilder.setUiLocales(additionalParameters.get("ui_locales"));
+            additionalParameters.remove("ui_locales");
+        }
+
         if (additionalParameters != null && !additionalParameters.isEmpty()) {
             authRequestBuilder.setAdditionalParameters(additionalParameters);
         }

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -307,12 +307,12 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
             authRequestBuilder.setResponseMode(responseMode);
         }
 
-        if(additionalParameters != null && !additionalParameters.isEmpty() && additionalParameters.containsKey("ui_locales")){
-            authRequestBuilder.setUiLocales(additionalParameters.get("ui_locales"));
-            additionalParameters.remove("ui_locales");
-        }
-
         if (additionalParameters != null && !additionalParameters.isEmpty()) {
+
+            if(additionalParameters.containsKey("ui_locales")){
+                authRequestBuilder.setUiLocales(additionalParameters.get("ui_locales"));
+                additionalParameters.remove("ui_locales");
+            }
             authRequestBuilder.setAdditionalParameters(additionalParameters);
         }
 


### PR DESCRIPTION
Added check in additionalParameters if there is ui_locales parameters, and set it in android with the new function which has been added at the last version of appAuth plugin otherwise application crashes