### PR TITLE
[flutter_appauth][flutter_appauth_platform_interface] fix: missing scopes in token response

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -26,6 +26,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -550,6 +551,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         responseMap.put("refreshToken", tokenResponse.refreshToken);
         responseMap.put("idToken", tokenResponse.idToken);
         responseMap.put("tokenType", tokenResponse.tokenType);
+        responseMap.put("scopes", tokenResponse.scope != null ? Arrays.asList(tokenResponse.scope.split(" ")) : null);
         if (authResponse != null) {
             responseMap.put("authorizationAdditionalParameters", authResponse.additionalParameters);
         }

--- a/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
@@ -395,6 +395,9 @@ NSString *const END_SESSION_ERROR_MESSAGE_FORMAT = @"Failed to end session: %@";
     if(tokenResponse.tokenType) {
         [processedResponses setValue:tokenResponse.tokenType forKey:@"tokenType"];
     }
+    if (tokenResponse.scope) {
+        [processedResponses setObject:[tokenResponse.scope componentsSeparatedByString: @" "] forKey:@"scopes"];
+    }
     
     return processedResponses;
 }

--- a/flutter_appauth_platform_interface/lib/src/authorization_token_response.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_token_response.dart
@@ -8,10 +8,11 @@ class AuthorizationTokenResponse extends TokenResponse {
     DateTime? accessTokenExpirationDateTime,
     String? idToken,
     String? tokenType,
+    List<String>? scopes,
     this.authorizationAdditionalParameters,
     Map<String, dynamic>? tokenAdditionalParameters,
   ) : super(accessToken, refreshToken, accessTokenExpirationDateTime, idToken,
-            tokenType, tokenAdditionalParameters);
+            tokenType, scopes, tokenAdditionalParameters);
 
   /// Contains additional parameters returned by the authorization server from making the authorization request.
   final Map<String, dynamic>? authorizationAdditionalParameters;

--- a/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
@@ -45,6 +45,7 @@ class MethodChannelFlutterAppAuth extends FlutterAppAuthPlatform {
                 result['accessTokenExpirationTime'].toInt()),
         result['idToken'],
         result['tokenType'],
+        result['scopes']?.cast<String>(),
         result['authorizationAdditionalParameters']?.cast<String, dynamic>(),
         result['tokenAdditionalParameters']?.cast<String, dynamic>());
   }
@@ -65,6 +66,7 @@ class MethodChannelFlutterAppAuth extends FlutterAppAuthPlatform {
                 result['accessTokenExpirationTime'].toInt()),
         result['idToken'],
         result['tokenType'],
+        result['scopes']?.cast<String>(),
         result['tokenAdditionalParameters']?.cast<String, dynamic>());
   }
 

--- a/flutter_appauth_platform_interface/lib/src/token_response.dart
+++ b/flutter_appauth_platform_interface/lib/src/token_response.dart
@@ -6,6 +6,7 @@ class TokenResponse {
     this.accessTokenExpirationDateTime,
     this.idToken,
     this.tokenType,
+    this.scopes,
     this.tokenAdditionalParameters,
   );
 
@@ -27,6 +28,9 @@ class TokenResponse {
 
   /// The type of token returned by the authorization server.
   final String? tokenType;
+
+  /// Scopes of the access token. If scopes are identical to those originally requested, then this value is optional.
+  final List<String>? scopes;
 
   /// Contains additional parameters returned by the authorization server from making the token request.
   final Map<String, dynamic>? tokenAdditionalParameters;


### PR DESCRIPTION
I hope I did the iOS part right - this was my first encounter with Obj-C and I don't have a way to test it.
The Android part works fine for me, so there and in the Dart code shouldn't be any issue.

Fixes #295.