### PR TITLE
[flutter_appauth] Skip HTTPS check for unsecure connections for attributes built 'onAttachedToEngine' method.

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -101,6 +101,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         defaultAuthorizationService = new AuthorizationService(this.applicationContext);
         AppAuthConfiguration.Builder authConfigBuilder = new AppAuthConfiguration.Builder();
         authConfigBuilder.setConnectionBuilder(InsecureConnectionBuilder.INSTANCE);
+        authConfigBuilder.setSkipIssuerHttpsCheck(true);
         insecureAuthorizationService = new AuthorizationService(applicationContext, authConfigBuilder.build());
         final MethodChannel channel = new MethodChannel(binaryMessenger, "crossingthestreams.io/flutter_appauth");
         channel.setMethodCallHandler(this);


### PR DESCRIPTION
This PR is to finish the fix started with the PR #228. This fix works fine for authorization, but on token refresh the HTTPS check error is triggered again.