### PR TITLE
[flutter_appauth][flutter_appauth_platform_interface] Use default system browser outside app

### DIFF
--- a/flutter_appauth/example/lib/main.dart
+++ b/flutter_appauth/example/lib/main.dart
@@ -91,6 +91,18 @@ class _MyAppState extends State<MyApp> {
                         preferEphemeralSession: true),
                   ),
                 ),
+              if (Platform.isIOS)
+                Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: ElevatedButton(
+                    child: const Text(
+                      'Sign in with auto code exchange using default system browser (iOS only)',
+                      textAlign: TextAlign.center,
+                    ),
+                    onPressed: () =>
+                        _signInWithAutoCodeExchange(defaultSystemBrowser: true),
+                  ),
+                ),
               ElevatedButton(
                 child: const Text('Refresh token'),
                 onPressed: _refreshToken != null ? _refresh : null,
@@ -216,7 +228,8 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future<void> _signInWithAutoCodeExchange(
-      {bool preferEphemeralSession = false}) async {
+      {bool preferEphemeralSession = false,
+      bool defaultSystemBrowser = false}) async {
     try {
       _setBusyState();
 
@@ -229,6 +242,7 @@ class _MyAppState extends State<MyApp> {
           serviceConfiguration: _serviceConfiguration,
           scopes: _scopes,
           preferEphemeralSession: preferEphemeralSession,
+          defaultSystemBrowser: defaultSystemBrowser,
         ),
       );
 

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -2,6 +2,7 @@ name: flutter_appauth
 description: This plugin provides an abstraction around the Android and iOS AppAuth SDKs so it can be used to communicate with OAuth 2.0 and OpenID Connect providers
 version: 2.4.1
 homepage: https://github.com/MaikuB/flutter_appauth/tree/master/flutter_appauth
+publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -10,7 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_appauth_platform_interface: ^4.1.0
+  flutter_appauth_platform_interface: 
+    path: ../flutter_appauth_platform_interface
 
 flutter:
   plugin:

--- a/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
@@ -7,8 +7,13 @@ mixin AuthorizationParameters {
 
   /// Whether to use an ephemeral session that prevents cookies and other browser data being shared with the user's normal browser session.
   ///
-  /// This property is only applicable to iOS versions 13 and above.
+  /// This property is only applicable to iOS versions 13 and above.  This setting is only validated when [defaultSystemBrowser] is set to false.
   bool? preferEphemeralSession;
 
   String? responseMode;
+
+  /// Whether to open the default system browser outside the app.
+  ///
+  /// This property is only applicable to iOS. Set this to true if you want to use the cookies/context of the system main browser (such as SSO flows). This setting will nullify [preferEphemeralSession].
+  bool? defaultSystemBrowser;
 }

--- a/flutter_appauth_platform_interface/lib/src/authorization_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_request.dart
@@ -18,6 +18,7 @@ class AuthorizationRequest extends CommonRequestDetails
     bool allowInsecureConnections = false,
     bool preferEphemeralSession = false,
     String? responseMode,
+    bool defaultSystemBrowser = false,
   }) {
     this.clientId = clientId;
     this.redirectUrl = redirectUrl;
@@ -31,6 +32,7 @@ class AuthorizationRequest extends CommonRequestDetails
     this.allowInsecureConnections = allowInsecureConnections;
     this.preferEphemeralSession = preferEphemeralSession;
     this.responseMode = responseMode;
+    this.defaultSystemBrowser = defaultSystemBrowser;
     assertConfigurationInfo();
   }
 }

--- a/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
@@ -20,6 +20,7 @@ class AuthorizationTokenRequest extends TokenRequest
     bool allowInsecureConnections = false,
     bool preferEphemeralSession = false,
     String? responseMode,
+    bool defaultSystemBrowser = false,
   }) : super(
           clientId,
           redirectUrl,
@@ -36,5 +37,6 @@ class AuthorizationTokenRequest extends TokenRequest
     this.promptValues = promptValues;
     this.preferEphemeralSession = preferEphemeralSession;
     this.responseMode = responseMode;
+    this.defaultSystemBrowser = defaultSystemBrowser;
   }
 }

--- a/flutter_appauth_platform_interface/lib/src/end_session_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/end_session_request.dart
@@ -11,6 +11,7 @@ class EndSessionRequest with AcceptedAuthorizationServiceConfigurationDetails {
     String? issuer,
     String? discoveryUrl,
     AuthorizationServiceConfiguration? serviceConfiguration,
+    this.defaultSystemBrowser = false,
   }) {
     assert((idTokenHint == null && postLogoutRedirectUrl == null) ||
         (idTokenHint != null && postLogoutRedirectUrl != null));
@@ -37,4 +38,9 @@ class EndSessionRequest with AcceptedAuthorizationServiceConfigurationDetails {
   bool allowInsecureConnections;
 
   final Map<String, String>? additionalParameters;
+
+  /// Whether to open the default system browser outside the app.
+  ///
+  /// This property is only applicable to iOS.
+  final bool defaultSystemBrowser;
 }

--- a/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
@@ -32,6 +32,7 @@ extension EndSessionRequestMapper on EndSessionRequest {
       'issuer': issuer,
       'discoveryUrl': discoveryUrl,
       'serviceConfiguration': serviceConfiguration?.toMap(),
+      'defaultSystemBrowser': defaultSystemBrowser,
     };
   }
 }
@@ -99,5 +100,6 @@ Map<String, Object?> _convertAuthorizationParametersToMap(
     'promptValues': authorizationParameters.promptValues,
     'preferEphemeralSession': authorizationParameters.preferEphemeralSession,
     'responseMode': authorizationParameters.responseMode,
+    'defaultSystemBrowser': authorizationParameters.defaultSystemBrowser,
   };
 }

--- a/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
+++ b/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
@@ -39,7 +39,8 @@ void main() {
           'allowInsecureConnections': false,
           'preferEphemeralSession': false,
           'promptValues': null,
-          'responseMode': null
+          'responseMode': null,
+          'defaultSystemBrowser': false,
         })
       ],
     );
@@ -48,7 +49,9 @@ void main() {
   test('authorizeAndExchangeCode', () async {
     await flutterAppAuth.authorizeAndExchangeCode(AuthorizationTokenRequest(
         'someClientId', 'someRedirectUrl',
-        discoveryUrl: 'someDiscoveryUrl', loginHint: 'someLoginHint', responseMode: 'fragment'));
+        discoveryUrl: 'someDiscoveryUrl',
+        loginHint: 'someLoginHint',
+        responseMode: 'fragment'));
     expect(
       log,
       <Matcher>[
@@ -69,7 +72,8 @@ void main() {
           'authorizationCode': null,
           'grantType': 'authorization_code',
           'codeVerifier': null,
-          'responseMode': 'fragment'
+          'responseMode': 'fragment',
+          'defaultSystemBrowser': false,
         })
       ],
     );
@@ -176,6 +180,7 @@ void main() {
         'issuer': null,
         'discoveryUrl': 'someDiscoveryUrl',
         'serviceConfiguration': null,
+        'defaultSystemBrowser': false,
       })
     ]);
   });


### PR DESCRIPTION
Hi,

For one of my clients, I needed to use the default system browser outside of the app, therefore I've added a `(bool) defaultSystemBrowser` property to `AuthorizationParameters` and `EndSessionRequest` which uses `[OIDExternalUserAgentIOSCustomBrowser CustomBrowserSafari]` in the `(id<OIDExternalUserAgent>)userAgentWithViewController` method.

This change is only for iOS. 

