### PR TITLE
 [flutter_appauth] using AppAuth 1.5.0

### DIFF
--- a/flutter_appauth/ios/flutter_appauth.podspec
+++ b/flutter_appauth/ios/flutter_appauth.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AppAuth', '1.4.0'
+  s.dependency 'AppAuth', '1.5.0'
   s.ios.deployment_target = '8.0'
 end
 

--- a/flutter_appauth/macos/flutter_appauth.podspec
+++ b/flutter_appauth/macos/flutter_appauth.podspec
@@ -15,7 +15,7 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'FlutterMacOS'
-  s.dependency 'AppAuth', '1.4.0'
+  s.dependency 'AppAuth', '1.5.0'
   s.platform = :osx, '10.11'
   s.osx.deployment_target = "10.11"
 end


### PR DESCRIPTION
just moving the AppAuth dependency to 1.5.0.
1.4.0 made it impossible to use this package and the latest version of [google_sign_in](https://pub.dev/packages/google_sign_in) package in the same app... (google_sign_in required 1.5.0 and flutter_appauth required 1.4.0)