### PR TITLE
[flutter_appauth][flutter_appauth_platform_interface] Add preferEphemeralSession option to logout

### DIFF
--- a/flutter_appauth/README.md
+++ b/flutter_appauth/README.md
@@ -113,8 +113,8 @@ to sign in and sign out.
 
 With an ephemeral session there will be no warning like `"app_name" Wants to Use "domain_name" to Sign In` on iOS.
 
-The option `preferEphemeralSession = true` must only be used for the end session call, if it is also used for the sign in call. 
-Otherwise there will be still an active login session in the browser.
+The option `preferEphemeralSession = true` must only be used for the end session call if it is also used for the sign in call. 
+Otherwise, there will be still an active login session in the browser.
 
 ## Android setup
 

--- a/flutter_appauth/README.md
+++ b/flutter_appauth/README.md
@@ -106,6 +106,16 @@ await appAuth.endSession(EndSessionRequest(
 
 The above code passes an `AuthorizationServiceConfiguration` with all the endpoints defined but alternatives are to specify an `issuer` or `discoveryUrl` like you would with the other APIs in the plugin (e.g. `authorizeAndExchangeCode()`).
 
+### Ephemeral Sessions (iOS and macOS only)
+On iOS (versions 13 and above) and macOS you can use the option `preferEphemeralSession = true` to start an 
+[ephemeral browser session](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1410529-ephemeral)
+to sign in and sign out.
+
+With an ephemeral session there will be no warning like `"app_name" Wants to Use "domain_name" to Sign In` on iOS.
+
+The option `preferEphemeralSession = true` must only be used for the end session call, if it is also used for the sign in call. 
+Otherwise there will be still an active login session in the browser.
+
 ## Android setup
 
 Go to the `build.gradle` file for your Android app to specify the custom scheme so that there should be a section in it that look similar to the following but replace `<your_custom_scheme>` with the desired value

--- a/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.m
+++ b/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.m
@@ -50,7 +50,7 @@
 
   UIViewController *rootViewController =
   [UIApplication sharedApplication].delegate.window.rootViewController;
-  id<OIDExternalUserAgent> externalUserAgent = [self userAgentWithViewController:rootViewController useEphemeralSession:false];
+  id<OIDExternalUserAgent> externalUserAgent = [self userAgentWithViewController:rootViewController useEphemeralSession:requestParameters.preferEphemeralSession];
 
   
   return [OIDAuthorizationService presentEndSessionRequest:endSessionRequest externalUserAgent:externalUserAgent callback:^(OIDEndSessionResponse * _Nullable endSessionResponse, NSError * _Nullable error) {

--- a/flutter_appauth/ios/Classes/FlutterAppAuth.h
+++ b/flutter_appauth/ios/Classes/FlutterAppAuth.h
@@ -39,6 +39,7 @@ static NSString *const END_SESSION_ERROR_MESSAGE_FORMAT = @"Failed to end sessio
 @property(nonatomic, strong) NSString *discoveryUrl;
 @property(nonatomic, strong) NSDictionary *serviceConfigurationParameters;
 @property(nonatomic, strong) NSDictionary *additionalParameters;
+@property(nonatomic, readwrite) BOOL preferEphemeralSession;
 @end
 
 @interface AppAuthAuthorization : NSObject

--- a/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
@@ -81,6 +81,7 @@
     _discoveryUrl = [ArgumentProcessor processArgumentValue:arguments withKey:@"discoveryUrl"];
     _serviceConfigurationParameters = [ArgumentProcessor processArgumentValue:arguments withKey:@"serviceConfiguration"];
     _additionalParameters = [ArgumentProcessor processArgumentValue:arguments withKey:@"additionalParameters"];
+    _preferEphemeralSession = [[ArgumentProcessor processArgumentValue:arguments withKey:@"preferEphemeralSession"] isEqual:@YES];
     return self;
 }
 @end

--- a/flutter_appauth/macos/Classes/AppAuthMacOSAuthorization.m
+++ b/flutter_appauth/macos/Classes/AppAuthMacOSAuthorization.m
@@ -48,7 +48,7 @@
                                                                                                                                                                                                                                                  additionalParameters:requestParameters.additionalParameters];
     
     NSWindow *keyWindow = [[NSApplication sharedApplication] keyWindow];
-    id<OIDExternalUserAgent> externalUserAgent = [self userAgentWithPresentingWindow:keyWindow useEphemeralSession:false];
+    id<OIDExternalUserAgent> externalUserAgent = [self userAgentWithPresentingWindow:keyWindow useEphemeralSession:requestParameters.preferEphemeralSession];
     return [OIDAuthorizationService presentEndSessionRequest:endSessionRequest externalUserAgent:externalUserAgent callback:^(OIDEndSessionResponse * _Nullable endSessionResponse, NSError * _Nullable error) {
         if(!endSessionResponse) {
             NSString *message = [NSString stringWithFormat:END_SESSION_ERROR_MESSAGE_FORMAT, [error localizedDescription]];

--- a/flutter_appauth_platform_interface/lib/src/end_session_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/end_session_request.dart
@@ -40,7 +40,7 @@ class EndSessionRequest with AcceptedAuthorizationServiceConfigurationDetails {
   /// Whether to use an ephemeral session that prevents cookies and other browser data being shared with the user's normal browser session.
   ///
   /// This property is only applicable to iOS versions 13 and above.
-  bool? preferEphemeralSession;
+  bool preferEphemeralSession;
 
   final Map<String, String>? additionalParameters;
 }

--- a/flutter_appauth_platform_interface/lib/src/end_session_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/end_session_request.dart
@@ -39,7 +39,9 @@ class EndSessionRequest with AcceptedAuthorizationServiceConfigurationDetails {
 
   /// Whether to use an ephemeral session that prevents cookies and other browser data being shared with the user's normal browser session.
   ///
-  /// This property is only applicable to iOS versions 13 and above.
+  /// This property is only applicable to iOS (versions 13 and above) and macOS.
+  ///
+  /// preferEphemeralSession = true must only be used here, if it is also used for the sign in call.
   bool preferEphemeralSession;
 
   final Map<String, String>? additionalParameters;

--- a/flutter_appauth_platform_interface/lib/src/end_session_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/end_session_request.dart
@@ -7,6 +7,7 @@ class EndSessionRequest with AcceptedAuthorizationServiceConfigurationDetails {
     this.postLogoutRedirectUrl,
     this.state,
     this.allowInsecureConnections = false,
+    this.preferEphemeralSession = false,
     this.additionalParameters,
     String? issuer,
     String? discoveryUrl,
@@ -35,6 +36,11 @@ class EndSessionRequest with AcceptedAuthorizationServiceConfigurationDetails {
   ///
   /// This property is only applicable to Android.
   bool allowInsecureConnections;
+
+  /// Whether to use an ephemeral session that prevents cookies and other browser data being shared with the user's normal browser session.
+  ///
+  /// This property is only applicable to iOS versions 13 and above.
+  bool? preferEphemeralSession;
 
   final Map<String, String>? additionalParameters;
 }

--- a/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
@@ -33,6 +33,7 @@ extension EndSessionRequestMapper on EndSessionRequest {
       'issuer': issuer,
       'discoveryUrl': discoveryUrl,
       'serviceConfiguration': serviceConfiguration?.toMap(),
+      'preferEphemeralSession': preferEphemeralSession,
     };
   }
 }

--- a/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
+++ b/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
@@ -183,6 +183,7 @@ void main() {
         'issuer': null,
         'discoveryUrl': 'someDiscoveryUrl',
         'serviceConfiguration': null,
+        'preferEphemeralSession': false,
       })
     ]);
   });


### PR DESCRIPTION
Hi,

at the moment it is possible to pass the option `preferEphemeralSession: true` to the sign in call, but not to the end session call. Therefore, before every logout a pop-up like this is shown to the user:
<img width="443" alt="image" src="https://user-images.githubusercontent.com/44165453/178540323-c9236144-b1ba-4f49-9752-27e96f5bb61e.png">

If no pop-up was displayed before the login, it would be nicer if there is also none before the logout. So, I added the functionality to set the `preferEphemeralSession` option also for the end session call.

It would be nice if this feature could be included into the library.