### PR TITLE
[flutter_appauth] docs: add alternative for appAuthRedirectScheme

### DIFF
--- a/flutter_appauth/README.md
+++ b/flutter_appauth/README.md
@@ -121,7 +121,7 @@ Otherwise, there will be still an active login session in the browser.
 Go to the `build.gradle` file for your Android app to specify the custom scheme so that there should be a section in it that look similar to the following but replace `<your_custom_scheme>` with the desired value
 
 ```
-...
+...groovy
 android {
     ...
     defaultConfig {
@@ -131,6 +131,30 @@ android {
         ]
     }
 }
+```
+
+Alternatively, the redirect URI can be directly configured by adding an
+intent-filter for AppAuth's RedirectUriReceiverActivity to your
+AndroidManifest.xml:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.my_app">
+...
+<activity
+        android:name="net.openid.appauth.RedirectUriReceiverActivity"
+        android:exported="true"
+        tools:node="replace">
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <category android:name="android.intent.category.BROWSABLE"/>
+        <data android:scheme="<your_custom_scheme>"
+              android:host="<your_custom_host>"/>
+    </intent-filter>
+</activity>
+...
 ```
 
 Please ensure that value of `<your_custom_scheme>` is all in lowercase as there've been reports from the community who had issues with redirects if there were any capital letters. You may also notice the `+=` operation is applied on `manifestPlaceholders` instead of `=`. This is intentional and required as newer versions of the Flutter SDK has made some changes underneath the hood to deal with multidex. Using `=` instead of `+=` can lead to errors like the following


### PR DESCRIPTION
Add as in the [AppAuth for Android documentation](https://github.com/openid/AppAuth-Android/blob/master/README.md#capturing-the-authorization-redirect) the alternative way to define the redirect scheme, which allows deep link flutter and OAuth 2.