### PR TITLE
[flutter_appauth] Expose native exception type and code to the Flutter code

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -629,7 +629,7 @@ public class FlutterAppauthPlugin
                             finishWithSuccess(tokenResponseToMap(resp, authResponse));
                         } else {
                             finishWithError(ex, AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE,
-                                    AUTHORIZE_AND_EXCHANGE_CODE_ERROR_MESSAGE_FORMAT);
+                                    AUTHORIZE_ERROR_MESSAGE_FORMAT);
                         }
                     }
                 };

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -44,7 +44,8 @@ import android.text.TextUtils;
 /**
  * FlutterAppauthPlugin
  */
-public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, PluginRegistry.ActivityResultListener, ActivityAware {
+public class FlutterAppauthPlugin
+        implements FlutterPlugin, MethodCallHandler, PluginRegistry.ActivityResultListener, ActivityAware {
     private static final String AUTHORIZE_AND_EXCHANGE_CODE_METHOD = "authorizeAndExchangeCode";
     private static final String AUTHORIZE_METHOD = "authorize";
     private static final String TOKEN_METHOD = "token";
@@ -92,7 +93,6 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     }
                 });
     }
-
 
     private void setActivity(Activity flutterActivity) {
         this.mainActivity = flutterActivity;
@@ -156,7 +156,6 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         pendingOperation = new PendingOperation(method, result);
     }
 
-
     @Override
     public void onMethodCall(MethodCall call, @NonNull Result result) {
         Map<String, Object> arguments = call.arguments();
@@ -166,7 +165,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     checkAndSetPendingOperation(call.method, result);
                     handleAuthorizeMethodCall(arguments, true);
                 } catch (Exception ex) {
-                    finishWithError(AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
+                    finishWithError(ex, AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE);
                 }
                 break;
             case AUTHORIZE_METHOD:
@@ -174,7 +173,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     checkAndSetPendingOperation(call.method, result);
                     handleAuthorizeMethodCall(arguments, false);
                 } catch (Exception ex) {
-                    finishWithError(AUTHORIZE_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
+                    finishWithError(ex, AUTHORIZE_ERROR_CODE);
                 }
                 break;
             case TOKEN_METHOD:
@@ -182,7 +181,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     checkAndSetPendingOperation(call.method, result);
                     handleTokenMethodCall(arguments);
                 } catch (Exception ex) {
-                    finishWithError(TOKEN_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
+                    finishWithError(ex, TOKEN_ERROR_CODE);
                 }
                 break;
             case END_SESSION_METHOD:
@@ -190,7 +189,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     checkAndSetPendingOperation(call.method, result);
                     handleEndSessionMethodCall(arguments);
                 } catch (Exception ex) {
-                    finishWithError(END_SESSION_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
+                    finishWithError(ex, END_SESSION_ERROR_CODE);
                 }
                 break;
             default:
@@ -199,7 +198,8 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     }
 
     @SuppressWarnings("unchecked")
-    private AuthorizationTokenRequestParameters processAuthorizationTokenRequestArguments(Map<String, Object> arguments) {
+    private AuthorizationTokenRequestParameters processAuthorizationTokenRequestArguments(
+            Map<String, Object> arguments) {
         final String clientId = (String) arguments.get("clientId");
         final String issuer = (String) arguments.get("issuer");
         final String discoveryUrl = (String) arguments.get("discoveryUrl");
@@ -209,12 +209,14 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         clientSecret = (String) arguments.get("clientSecret");
         final ArrayList<String> scopes = (ArrayList<String>) arguments.get("scopes");
         final ArrayList<String> promptValues = (ArrayList<String>) arguments.get("promptValues");
-        Map<String, String> serviceConfigurationParameters = (Map<String, String>) arguments.get("serviceConfiguration");
+        Map<String, String> serviceConfigurationParameters = (Map<String, String>) arguments
+                .get("serviceConfiguration");
         Map<String, String> additionalParameters = (Map<String, String>) arguments.get("additionalParameters");
         allowInsecureConnections = (boolean) arguments.get("allowInsecureConnections");
         final String responseMode = (String) arguments.get("responseMode");
 
-        return new AuthorizationTokenRequestParameters(clientId, issuer, discoveryUrl, scopes, redirectUrl, serviceConfigurationParameters, additionalParameters, loginHint, nonce, promptValues, responseMode);
+        return new AuthorizationTokenRequestParameters(clientId, issuer, discoveryUrl, scopes, redirectUrl,
+                serviceConfigurationParameters, additionalParameters, loginHint, nonce, promptValues, responseMode);
     }
 
     @SuppressWarnings("unchecked")
@@ -242,10 +244,13 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
             nonce = (String) arguments.get("nonce");
         }
         final ArrayList<String> scopes = (ArrayList<String>) arguments.get("scopes");
-        final Map<String, String> serviceConfigurationParameters = (Map<String, String>) arguments.get("serviceConfiguration");
+        final Map<String, String> serviceConfigurationParameters = (Map<String, String>) arguments
+                .get("serviceConfiguration");
         final Map<String, String> additionalParameters = (Map<String, String>) arguments.get("additionalParameters");
         allowInsecureConnections = (boolean) arguments.get("allowInsecureConnections");
-        return new TokenRequestParameters(clientId, issuer, discoveryUrl, scopes, redirectUrl, refreshToken, authorizationCode, codeVerifier, nonce, grantType, serviceConfigurationParameters, additionalParameters);
+        return new TokenRequestParameters(clientId, issuer, discoveryUrl, scopes, redirectUrl, refreshToken,
+                authorizationCode, codeVerifier, nonce, grantType, serviceConfigurationParameters,
+                additionalParameters);
     }
 
     @SuppressWarnings("unchecked")
@@ -256,49 +261,73 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         final boolean allowInsecureConnections = (boolean) arguments.get("allowInsecureConnections");
         final String issuer = (String) arguments.get("issuer");
         final String discoveryUrl = (String) arguments.get("discoveryUrl");
-        final Map<String, String> serviceConfigurationParameters = (Map<String, String>) arguments.get("serviceConfiguration");
+        final Map<String, String> serviceConfigurationParameters = (Map<String, String>) arguments
+                .get("serviceConfiguration");
         final Map<String, String> additionalParameters = (Map<String, String>) arguments.get("additionalParameters");
-        return new EndSessionRequestParameters(idTokenHint, postLogoutRedirectUrl, state, issuer, discoveryUrl, allowInsecureConnections, serviceConfigurationParameters, additionalParameters);
+        return new EndSessionRequestParameters(idTokenHint, postLogoutRedirectUrl, state, issuer, discoveryUrl,
+                allowInsecureConnections, serviceConfigurationParameters, additionalParameters);
     }
 
     private void handleAuthorizeMethodCall(Map<String, Object> arguments, final boolean exchangeCode) {
-        final AuthorizationTokenRequestParameters tokenRequestParameters = processAuthorizationTokenRequestArguments(arguments);
+        final AuthorizationTokenRequestParameters tokenRequestParameters = processAuthorizationTokenRequestArguments(
+                arguments);
         if (tokenRequestParameters.serviceConfigurationParameters != null) {
-            AuthorizationServiceConfiguration serviceConfiguration = processServiceConfigurationParameters(tokenRequestParameters.serviceConfigurationParameters);
-            performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.nonce, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues, tokenRequestParameters.responseMode);
+            AuthorizationServiceConfiguration serviceConfiguration = processServiceConfigurationParameters(
+                    tokenRequestParameters.serviceConfigurationParameters);
+            performAuthorization(serviceConfiguration, tokenRequestParameters.clientId,
+                    tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint,
+                    tokenRequestParameters.nonce, tokenRequestParameters.additionalParameters, exchangeCode,
+                    tokenRequestParameters.promptValues, tokenRequestParameters.responseMode);
         } else {
             AuthorizationServiceConfiguration.RetrieveConfigurationCallback callback = new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
                 @Override
-                public void onFetchConfigurationCompleted(@Nullable AuthorizationServiceConfiguration serviceConfiguration, @Nullable AuthorizationException ex) {
+                public void onFetchConfigurationCompleted(
+                        @Nullable AuthorizationServiceConfiguration serviceConfiguration,
+                        @Nullable AuthorizationException ex) {
                     if (ex == null) {
-                        performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.nonce, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues, tokenRequestParameters.responseMode);
+                        performAuthorization(serviceConfiguration, tokenRequestParameters.clientId,
+                                tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes,
+                                tokenRequestParameters.loginHint, tokenRequestParameters.nonce,
+                                tokenRequestParameters.additionalParameters, exchangeCode,
+                                tokenRequestParameters.promptValues, tokenRequestParameters.responseMode);
                     } else {
                         finishWithDiscoveryError(ex);
                     }
                 }
             };
             if (tokenRequestParameters.discoveryUrl != null) {
-                AuthorizationServiceConfiguration.fetchFromUrl(Uri.parse(tokenRequestParameters.discoveryUrl), callback, allowInsecureConnections ? InsecureConnectionBuilder.INSTANCE : DefaultConnectionBuilder.INSTANCE);
+                AuthorizationServiceConfiguration.fetchFromUrl(Uri.parse(tokenRequestParameters.discoveryUrl), callback,
+                        allowInsecureConnections ? InsecureConnectionBuilder.INSTANCE
+                                : DefaultConnectionBuilder.INSTANCE);
             } else {
-                AuthorizationServiceConfiguration.fetchFromIssuer(Uri.parse(tokenRequestParameters.issuer), callback, allowInsecureConnections ? InsecureConnectionBuilder.INSTANCE : DefaultConnectionBuilder.INSTANCE);
+                AuthorizationServiceConfiguration.fetchFromIssuer(Uri.parse(tokenRequestParameters.issuer), callback,
+                        allowInsecureConnections ? InsecureConnectionBuilder.INSTANCE
+                                : DefaultConnectionBuilder.INSTANCE);
             }
         }
     }
 
-    private AuthorizationServiceConfiguration processServiceConfigurationParameters(Map<String, String> serviceConfigurationArguments) {
+    private AuthorizationServiceConfiguration processServiceConfigurationParameters(
+            Map<String, String> serviceConfigurationArguments) {
         final String endSessionEndpoint = serviceConfigurationArguments.get("endSessionEndpoint");
-        return new AuthorizationServiceConfiguration(Uri.parse(serviceConfigurationArguments.get("authorizationEndpoint")), Uri.parse(serviceConfigurationArguments.get("tokenEndpoint")), null, endSessionEndpoint == null ? null : Uri.parse(endSessionEndpoint));
+        return new AuthorizationServiceConfiguration(
+                Uri.parse(serviceConfigurationArguments.get("authorizationEndpoint")),
+                Uri.parse(serviceConfigurationArguments.get("tokenEndpoint")), null,
+                endSessionEndpoint == null ? null : Uri.parse(endSessionEndpoint));
     }
 
     private void handleTokenMethodCall(Map<String, Object> arguments) {
         final TokenRequestParameters tokenRequestParameters = processTokenRequestArguments(arguments);
         if (tokenRequestParameters.serviceConfigurationParameters != null) {
-            AuthorizationServiceConfiguration serviceConfiguration = processServiceConfigurationParameters(tokenRequestParameters.serviceConfigurationParameters);
+            AuthorizationServiceConfiguration serviceConfiguration = processServiceConfigurationParameters(
+                    tokenRequestParameters.serviceConfigurationParameters);
             performTokenRequest(serviceConfiguration, tokenRequestParameters);
         } else {
             AuthorizationServiceConfiguration.RetrieveConfigurationCallback callback = new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
                 @Override
-                public void onFetchConfigurationCompleted(@Nullable AuthorizationServiceConfiguration serviceConfiguration, @Nullable AuthorizationException ex) {
+                public void onFetchConfigurationCompleted(
+                        @Nullable AuthorizationServiceConfiguration serviceConfiguration,
+                        @Nullable AuthorizationException ex) {
                     if (ex == null) {
                         performTokenRequest(serviceConfiguration, tokenRequestParameters);
                     } else {
@@ -307,21 +336,26 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                 }
             };
             if (tokenRequestParameters.discoveryUrl != null) {
-                AuthorizationServiceConfiguration.fetchFromUrl(Uri.parse(tokenRequestParameters.discoveryUrl), callback, allowInsecureConnections ? InsecureConnectionBuilder.INSTANCE : DefaultConnectionBuilder.INSTANCE);
+                AuthorizationServiceConfiguration.fetchFromUrl(Uri.parse(tokenRequestParameters.discoveryUrl), callback,
+                        allowInsecureConnections ? InsecureConnectionBuilder.INSTANCE
+                                : DefaultConnectionBuilder.INSTANCE);
             } else {
-                AuthorizationServiceConfiguration.fetchFromIssuer(Uri.parse(tokenRequestParameters.issuer), callback, allowInsecureConnections ? InsecureConnectionBuilder.INSTANCE : DefaultConnectionBuilder.INSTANCE);
+                AuthorizationServiceConfiguration.fetchFromIssuer(Uri.parse(tokenRequestParameters.issuer), callback,
+                        allowInsecureConnections ? InsecureConnectionBuilder.INSTANCE
+                                : DefaultConnectionBuilder.INSTANCE);
             }
         }
     }
 
-
-    private void performAuthorization(AuthorizationServiceConfiguration serviceConfiguration, String clientId, String redirectUrl, ArrayList<String> scopes, String loginHint, String nonce, Map<String, String> additionalParameters, boolean exchangeCode, ArrayList<String> promptValues, String responseMode) {
-        AuthorizationRequest.Builder authRequestBuilder =
-                new AuthorizationRequest.Builder(
-                        serviceConfiguration,
-                        clientId,
-                        ResponseTypeValues.CODE,
-                        Uri.parse(redirectUrl));
+    private void performAuthorization(AuthorizationServiceConfiguration serviceConfiguration, String clientId,
+            String redirectUrl, ArrayList<String> scopes, String loginHint, String nonce,
+            Map<String, String> additionalParameters, boolean exchangeCode, ArrayList<String> promptValues,
+            String responseMode) {
+        AuthorizationRequest.Builder authRequestBuilder = new AuthorizationRequest.Builder(
+                serviceConfiguration,
+                clientId,
+                ResponseTypeValues.CODE,
+                Uri.parse(redirectUrl));
 
         if (scopes != null && !scopes.isEmpty()) {
             authRequestBuilder.setScopes(scopes);
@@ -345,19 +379,18 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
 
         if (additionalParameters != null && !additionalParameters.isEmpty()) {
 
-            if(additionalParameters.containsKey("ui_locales")){
+            if (additionalParameters.containsKey("ui_locales")) {
                 authRequestBuilder.setUiLocales(additionalParameters.get("ui_locales"));
                 additionalParameters.remove("ui_locales");
             }
 
-            if(additionalParameters.containsKey("claims")){
+            if (additionalParameters.containsKey("claims")) {
                 try {
                     final JSONObject claimsAsJson = new JSONObject(additionalParameters.get("claims"));
                     authRequestBuilder.setClaims(claimsAsJson);
                     additionalParameters.remove("claims");
-                }
-                catch (JSONException ex) {
-                    finishWithError(INVALID_CLAIMS_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
+                } catch (JSONException ex) {
+                    finishWithError(ex, INVALID_CLAIMS_ERROR_CODE);
                     return;
                 }
             }
@@ -365,12 +398,14 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
             authRequestBuilder.setAdditionalParameters(additionalParameters);
         }
 
-        AuthorizationService authorizationService = allowInsecureConnections ? insecureAuthorizationService : defaultAuthorizationService;
+        AuthorizationService authorizationService = allowInsecureConnections ? insecureAuthorizationService
+                : defaultAuthorizationService;
         Intent authIntent = authorizationService.getAuthorizationRequestIntent(authRequestBuilder.build());
         mainActivity.startActivityForResult(authIntent, exchangeCode ? RC_AUTH_EXCHANGE_CODE : RC_AUTH);
     }
 
-    private void performTokenRequest(AuthorizationServiceConfiguration serviceConfiguration, TokenRequestParameters tokenRequestParameters) {
+    private void performTokenRequest(AuthorizationServiceConfiguration serviceConfiguration,
+            TokenRequestParameters tokenRequestParameters) {
         TokenRequest.Builder builder = new TokenRequest.Builder(serviceConfiguration, tokenRequestParameters.clientId)
                 .setRefreshToken(tokenRequestParameters.refreshToken)
                 .setAuthorizationCode(tokenRequestParameters.authorizationCode)
@@ -387,7 +422,8 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
             builder.setScopes(tokenRequestParameters.scopes);
         }
 
-        if (tokenRequestParameters.additionalParameters != null && !tokenRequestParameters.additionalParameters.isEmpty()) {
+        if (tokenRequestParameters.additionalParameters != null
+                && !tokenRequestParameters.additionalParameters.isEmpty()) {
             builder.setAdditionalParameters(tokenRequestParameters.additionalParameters);
         }
 
@@ -405,23 +441,28 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         };
 
         TokenRequest tokenRequest = builder.build();
-        AuthorizationService authorizationService = allowInsecureConnections ? insecureAuthorizationService : defaultAuthorizationService;
+        AuthorizationService authorizationService = allowInsecureConnections ? insecureAuthorizationService
+                : defaultAuthorizationService;
         if (clientSecret == null) {
             authorizationService.performTokenRequest(tokenRequest, tokenResponseCallback);
         } else {
-            authorizationService.performTokenRequest(tokenRequest, new ClientSecretBasic(clientSecret), tokenResponseCallback);
+            authorizationService.performTokenRequest(tokenRequest, new ClientSecretBasic(clientSecret),
+                    tokenResponseCallback);
         }
     }
 
     private void handleEndSessionMethodCall(Map<String, Object> arguments) {
         final EndSessionRequestParameters endSessionRequestParameters = processEndSessionRequestArguments(arguments);
         if (endSessionRequestParameters.serviceConfigurationParameters != null) {
-            AuthorizationServiceConfiguration serviceConfiguration = processServiceConfigurationParameters(endSessionRequestParameters.serviceConfigurationParameters);
+            AuthorizationServiceConfiguration serviceConfiguration = processServiceConfigurationParameters(
+                    endSessionRequestParameters.serviceConfigurationParameters);
             performEndSessionRequest(serviceConfiguration, endSessionRequestParameters);
         } else {
             AuthorizationServiceConfiguration.RetrieveConfigurationCallback callback = new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
                 @Override
-                public void onFetchConfigurationCompleted(@Nullable AuthorizationServiceConfiguration serviceConfiguration, @Nullable AuthorizationException ex) {
+                public void onFetchConfigurationCompleted(
+                        @Nullable AuthorizationServiceConfiguration serviceConfiguration,
+                        @Nullable AuthorizationException ex) {
                     if (ex == null) {
                         performEndSessionRequest(serviceConfiguration, endSessionRequestParameters);
                     } else {
@@ -431,21 +472,27 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
             };
 
             if (endSessionRequestParameters.discoveryUrl != null) {
-                AuthorizationServiceConfiguration.fetchFromUrl(Uri.parse(endSessionRequestParameters.discoveryUrl), callback, allowInsecureConnections ? InsecureConnectionBuilder.INSTANCE : DefaultConnectionBuilder.INSTANCE);
+                AuthorizationServiceConfiguration.fetchFromUrl(Uri.parse(endSessionRequestParameters.discoveryUrl),
+                        callback, allowInsecureConnections ? InsecureConnectionBuilder.INSTANCE
+                                : DefaultConnectionBuilder.INSTANCE);
             } else {
-                AuthorizationServiceConfiguration.fetchFromIssuer(Uri.parse(endSessionRequestParameters.issuer), callback, allowInsecureConnections ? InsecureConnectionBuilder.INSTANCE : DefaultConnectionBuilder.INSTANCE);
+                AuthorizationServiceConfiguration.fetchFromIssuer(Uri.parse(endSessionRequestParameters.issuer),
+                        callback, allowInsecureConnections ? InsecureConnectionBuilder.INSTANCE
+                                : DefaultConnectionBuilder.INSTANCE);
             }
         }
     }
 
-    private void performEndSessionRequest(AuthorizationServiceConfiguration serviceConfiguration, final EndSessionRequestParameters endSessionRequestParameters) {
+    private void performEndSessionRequest(AuthorizationServiceConfiguration serviceConfiguration,
+            final EndSessionRequestParameters endSessionRequestParameters) {
         EndSessionRequest.Builder endSessionRequestBuilder = new EndSessionRequest.Builder(serviceConfiguration);
         if (endSessionRequestParameters.idTokenHint != null) {
             endSessionRequestBuilder.setIdTokenHint(endSessionRequestParameters.idTokenHint);
         }
 
         if (endSessionRequestParameters.postLogoutRedirectUrl != null) {
-            endSessionRequestBuilder.setPostLogoutRedirectUri(Uri.parse(endSessionRequestParameters.postLogoutRedirectUrl));
+            endSessionRequestBuilder
+                    .setPostLogoutRedirectUri(Uri.parse(endSessionRequestParameters.postLogoutRedirectUrl));
         }
 
         if (endSessionRequestParameters.state != null) {
@@ -457,21 +504,65 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         }
 
         final EndSessionRequest endSessionRequest = endSessionRequestBuilder.build();
-        AuthorizationService authorizationService = allowInsecureConnections ? insecureAuthorizationService : defaultAuthorizationService;
+        AuthorizationService authorizationService = allowInsecureConnections ? insecureAuthorizationService
+                : defaultAuthorizationService;
         Intent endSessionIntent = authorizationService.getEndSessionRequestIntent(endSessionRequest);
         mainActivity.startActivityForResult(endSessionIntent, RC_END_SESSION);
     }
 
     private void finishWithTokenError(AuthorizationException ex) {
-        finishWithError(TOKEN_ERROR_CODE, String.format(TOKEN_ERROR_MESSAGE_FORMAT, ex.error, ex.errorDescription), getCauseFromException(ex));
+        finishWithError(ex, TOKEN_ERROR_CODE, TOKEN_ERROR_MESSAGE_FORMAT);
     }
-
 
     private void finishWithSuccess(Object data) {
         if (pendingOperation != null) {
             pendingOperation.result.success(data);
             pendingOperation = null;
         }
+    }
+
+    private void finishWithError(AuthorizationException ex, String errorCode, String messageFormat) {
+        finishWithError(getErrorCode(errorCode, ex), getMessage(messageFormat, ex), getCauseFromException(ex));
+    }
+
+    private void finishWithError(Exception ex, String errorCode) {
+        finishWithError(getErrorCode(errorCode, ex), ex.getLocalizedMessage(), getCauseFromException(ex));
+    }
+
+    private String getErrorCode(String baseCode, Exception ex) {
+        if (ex instanceof AuthorizationException) {
+            return getErrorCode(baseCode, (AuthorizationException) ex);
+        } else {
+            return baseCode;
+        }
+    }
+
+    private String getErrorCode(String baseCode, AuthorizationException ex) {
+        return String.format("%s:%s:%s", baseCode, getTypeCode(ex), ex.code);
+    }
+
+    private String getTypeCode(AuthorizationException ex) {
+        switch (ex.type) {
+            case AuthorizationException.TYPE_GENERAL_ERROR:
+                return "GENERAL_ERROR";
+            case AuthorizationException.TYPE_OAUTH_AUTHORIZATION_ERROR:
+                return "OAUTH_AUTHORIZATION_ERROR";
+            case AuthorizationException.TYPE_OAUTH_TOKEN_ERROR:
+                return "OAUTH_TOKEN_ERROR";
+            case AuthorizationException.TYPE_RESOURCE_SERVER_AUTHORIZATION_ERROR:
+                return "RESOURCE_SERVER_AUTHORIZATION_ERROR";
+            default:
+                return "UNKNOWN_ERROR";
+        }
+    }
+
+    private String getMessage(String format, AuthorizationException ex) {
+        return String.format(format, ex.error, ex.errorDescription);
+    }
+
+    private String getCauseFromException(Exception ex) {
+        final Throwable cause = ex.getCause();
+        return cause != null ? cause.getMessage() : null;
     }
 
     private void finishWithError(String errorCode, String errorMessage, String errorDetails) {
@@ -482,18 +573,12 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     }
 
     private void finishWithDiscoveryError(AuthorizationException ex) {
-        finishWithError(DISCOVERY_ERROR_CODE, String.format(DISCOVERY_ERROR_MESSAGE_FORMAT, ex.error, ex.errorDescription), getCauseFromException(ex));
+        finishWithError(ex, DISCOVERY_ERROR_CODE, DISCOVERY_ERROR_MESSAGE_FORMAT);
     }
 
     private void finishWithEndSessionError(AuthorizationException ex) {
-        finishWithError(END_SESSION_ERROR_CODE, String.format(END_SESSION_ERROR_MESSAGE_FORMAT, ex.error, ex.errorDescription), getCauseFromException(ex));
+        finishWithError(ex, END_SESSION_ERROR_CODE, END_SESSION_ERROR_MESSAGE_FORMAT);
     }
-
-    private String getCauseFromException(Exception ex) {
-        final Throwable cause = ex.getCause();
-        return cause != null ? cause.getMessage() : null;
-    }
-
 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent intent) {
@@ -524,7 +609,8 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         return false;
     }
 
-    private void processAuthorizationData(final AuthorizationResponse authResponse, AuthorizationException authException, boolean exchangeCode) {
+    private void processAuthorizationData(final AuthorizationResponse authResponse,
+            AuthorizationException authException, boolean exchangeCode) {
         if (authException == null) {
             if (exchangeCode) {
                 AppAuthConfiguration.Builder authConfigBuilder = new AppAuthConfiguration.Builder();
@@ -533,7 +619,8 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     authConfigBuilder.setSkipIssuerHttpsCheck(true);
                 }
 
-                AuthorizationService authService = new AuthorizationService(applicationContext, authConfigBuilder.build());
+                AuthorizationService authService = new AuthorizationService(applicationContext,
+                        authConfigBuilder.build());
                 AuthorizationService.TokenResponseCallback tokenResponseCallback = new AuthorizationService.TokenResponseCallback() {
                     @Override
                     public void onTokenRequestCompleted(
@@ -541,27 +628,34 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                         if (resp != null) {
                             finishWithSuccess(tokenResponseToMap(resp, authResponse));
                         } else {
-                            finishWithError(AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE, String.format(AUTHORIZE_ERROR_MESSAGE_FORMAT, ex.error, ex.errorDescription), getCauseFromException(ex));
+                            finishWithError(ex, AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE,
+                                    AUTHORIZE_AND_EXCHANGE_CODE_ERROR_MESSAGE_FORMAT);
                         }
                     }
                 };
                 if (clientSecret == null) {
                     authService.performTokenRequest(authResponse.createTokenExchangeRequest(), tokenResponseCallback);
                 } else {
-                    authService.performTokenRequest(authResponse.createTokenExchangeRequest(), new ClientSecretBasic(clientSecret), tokenResponseCallback);
+                    authService.performTokenRequest(authResponse.createTokenExchangeRequest(),
+                            new ClientSecretBasic(clientSecret), tokenResponseCallback);
                 }
             } else {
                 finishWithSuccess(authorizationResponseToMap(authResponse));
             }
         } else {
-            finishWithError(exchangeCode ? AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE : AUTHORIZE_ERROR_CODE, String.format(AUTHORIZE_ERROR_MESSAGE_FORMAT, authException.error, authException.errorDescription), getCauseFromException(authException));
+            finishWithError(
+                    authException,
+                    exchangeCode ? AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE : AUTHORIZE_ERROR_CODE,
+                    AUTHORIZE_ERROR_MESSAGE_FORMAT);
         }
     }
 
     private Map<String, Object> tokenResponseToMap(TokenResponse tokenResponse, AuthorizationResponse authResponse) {
         Map<String, Object> responseMap = new HashMap<>();
         responseMap.put("accessToken", tokenResponse.accessToken);
-        responseMap.put("accessTokenExpirationTime", tokenResponse.accessTokenExpirationTime != null ? tokenResponse.accessTokenExpirationTime.doubleValue() : null);
+        responseMap.put("accessTokenExpirationTime",
+                tokenResponse.accessTokenExpirationTime != null ? tokenResponse.accessTokenExpirationTime.doubleValue()
+                        : null);
         responseMap.put("refreshToken", tokenResponse.refreshToken);
         responseMap.put("idToken", tokenResponse.idToken);
         responseMap.put("tokenType", tokenResponse.tokenType);
@@ -607,7 +701,10 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         final Map<String, String> serviceConfigurationParameters;
         final Map<String, String> additionalParameters;
 
-        private TokenRequestParameters(String clientId, String issuer, String discoveryUrl, ArrayList<String> scopes, String redirectUrl, String refreshToken, String authorizationCode, String codeVerifier, String nonce, String grantType, Map<String, String> serviceConfigurationParameters, Map<String, String> additionalParameters) {
+        private TokenRequestParameters(String clientId, String issuer, String discoveryUrl, ArrayList<String> scopes,
+                String redirectUrl, String refreshToken, String authorizationCode, String codeVerifier, String nonce,
+                String grantType, Map<String, String> serviceConfigurationParameters,
+                Map<String, String> additionalParameters) {
             this.clientId = clientId;
             this.issuer = issuer;
             this.discoveryUrl = discoveryUrl;
@@ -633,7 +730,9 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         final Map<String, String> serviceConfigurationParameters;
         final Map<String, String> additionalParameters;
 
-        private EndSessionRequestParameters(String idTokenHint, String postLogoutRedirectUrl, String state, String issuer, String discoveryUrl, boolean allowInsecureConnections, Map<String, String> serviceConfigurationParameters, Map<String, String> additionalParameters) {
+        private EndSessionRequestParameters(String idTokenHint, String postLogoutRedirectUrl, String state,
+                String issuer, String discoveryUrl, boolean allowInsecureConnections,
+                Map<String, String> serviceConfigurationParameters, Map<String, String> additionalParameters) {
             this.idTokenHint = idTokenHint;
             this.postLogoutRedirectUrl = postLogoutRedirectUrl;
             this.state = state;
@@ -650,8 +749,12 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         final ArrayList<String> promptValues;
         final String responseMode;
 
-        private AuthorizationTokenRequestParameters(String clientId, String issuer, String discoveryUrl, ArrayList<String> scopes, String redirectUrl, Map<String, String> serviceConfigurationParameters, Map<String, String> additionalParameters, String loginHint, String nonce, ArrayList<String> promptValues, String responseMode) {
-            super(clientId, issuer, discoveryUrl, scopes, redirectUrl, null, null, null, nonce, null, serviceConfigurationParameters, additionalParameters);
+        private AuthorizationTokenRequestParameters(String clientId, String issuer, String discoveryUrl,
+                ArrayList<String> scopes, String redirectUrl, Map<String, String> serviceConfigurationParameters,
+                Map<String, String> additionalParameters, String loginHint, String nonce,
+                ArrayList<String> promptValues, String responseMode) {
+            super(clientId, issuer, discoveryUrl, scopes, redirectUrl, null, null, null, nonce, null,
+                    serviceConfigurationParameters, additionalParameters);
             this.loginHint = loginHint;
             this.promptValues = promptValues;
             this.responseMode = responseMode;

--- a/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.m
+++ b/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.m
@@ -27,9 +27,9 @@
                                                                                                                                                   NSError *_Nullable error) {
           if(authState) {
               result([FlutterAppAuth processResponses:authState.lastTokenResponse authResponse:authState.lastAuthorizationResponse]);
-              
+
           } else {
-              [FlutterAppAuth finishWithError:AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE message:[FlutterAppAuth formatMessageWithError:AUTHORIZE_ERROR_MESSAGE_FORMAT error:error] result:result];
+              [FlutterAppAuth finishWithError:error errorCode:AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE messageFormat:AUTHORIZE_ERROR_MESSAGE_FORMAT result:result];
           }
       }];
   } else {
@@ -43,7 +43,7 @@
               [processedResponse setObject:authorizationResponse.request.nonce forKey:@"nonce"];
               result(processedResponse);
           } else {
-              [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE message:[FlutterAppAuth formatMessageWithError:AUTHORIZE_ERROR_MESSAGE_FORMAT error:error] result:result];
+              [FlutterAppAuth finishWithError:error errorCode:AUTHORIZE_ERROR_CODE messageFormat:AUTHORIZE_ERROR_MESSAGE_FORMAT result:result];
           }
       }];
   }
@@ -51,7 +51,7 @@
 
 - (id<OIDExternalUserAgentSession>)performEndSessionRequest:(OIDServiceConfiguration *)serviceConfiguration requestParameters:(EndSessionRequestParameters *)requestParameters result:(FlutterResult)result {
   NSURL *postLogoutRedirectURL = requestParameters.postLogoutRedirectUrl ? [NSURL URLWithString:requestParameters.postLogoutRedirectUrl] : nil;
-  
+
   OIDEndSessionRequest *endSessionRequest = requestParameters.state ? [[OIDEndSessionRequest alloc] initWithConfiguration:serviceConfiguration idTokenHint:requestParameters.idTokenHint postLogoutRedirectURL:postLogoutRedirectURL
                                                                                                                     state:requestParameters.state additionalParameters:requestParameters.additionalParameters] :[[OIDEndSessionRequest alloc] initWithConfiguration:serviceConfiguration idTokenHint:requestParameters.idTokenHint postLogoutRedirectURL:postLogoutRedirectURL
                                                                                                                                                                                                                                                additionalParameters:requestParameters.additionalParameters];
@@ -60,11 +60,10 @@
   [UIApplication sharedApplication].delegate.window.rootViewController;
   id<OIDExternalUserAgent> externalUserAgent = [self userAgentWithViewController:rootViewController useEphemeralSession:requestParameters.preferEphemeralSession];
 
-  
+
   return [OIDAuthorizationService presentEndSessionRequest:endSessionRequest externalUserAgent:externalUserAgent callback:^(OIDEndSessionResponse * _Nullable endSessionResponse, NSError * _Nullable error) {
       if(!endSessionResponse) {
-          NSString *message = [NSString stringWithFormat:END_SESSION_ERROR_MESSAGE_FORMAT, [error localizedDescription]];
-          [FlutterAppAuth finishWithError:END_SESSION_ERROR_CODE message:message result:result];
+          [FlutterAppAuth finishWithError:error errorCode:END_SESSION_ERROR_CODE messageFormat:END_SESSION_ERROR_MESSAGE_FORMAT result:result];
           return;
       }
       NSMutableDictionary *processedResponse = [[NSMutableDictionary alloc] init];

--- a/flutter_appauth/ios/Classes/FlutterAppAuth.h
+++ b/flutter_appauth/ios/Classes/FlutterAppAuth.h
@@ -11,9 +11,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface FlutterAppAuth : NSObject
 
-+ (NSMutableDictionary *)processResponses:(OIDTokenResponse*) tokenResponse authResponse:(OIDAuthorizationResponse* _Nullable) authResponse;
-+ (void)finishWithError:(NSError * _Nullable)error, errorCode:(NSString *)baseCode, messageFormat:(NSString *)messageFormat, result:(FlutterResult)result;
-
++ (NSMutableDictionary *)processResponses:(OIDTokenResponse*) tokenResponse
+                             authResponse:(OIDAuthorizationResponse* _Nullable) authResponse;
++ (void)finishWithError:(NSError * _Nullable)error
+              errorCode:(NSString *)baseCode
+          messageFormat:(NSString *)messageFormat
+                 result:(FlutterResult)result;
 @end
 
 static NSString *const AUTHORIZE_METHOD = @"authorize";
@@ -43,10 +46,20 @@ static NSString *const END_SESSION_ERROR_MESSAGE_FORMAT = @"Failed to end sessio
 
 @interface AppAuthAuthorization : NSObject
 
-- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(NSString*)nonce;
+- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration
+                                               clientId:(NSString*)clientId
+                                           clientSecret:(NSString*)clientSecret
+                                                 scopes:(NSArray *)scopes
+                                            redirectUrl:(NSString*)redirectUrl
+                                   additionalParameters:(NSDictionary *)additionalParameters
+                                 preferEphemeralSession:(BOOL)preferEphemeralSession
+                                                 result:(FlutterResult)result
+                                           exchangeCode:(BOOL)exchangeCode
+                                                  nonce:(NSString*)nonce;
 
-- (id<OIDExternalUserAgentSession>)performEndSessionRequest:(OIDServiceConfiguration *)serviceConfiguration requestParameters:(EndSessionRequestParameters *)requestParameters result:(FlutterResult)result;
-
+- (id<OIDExternalUserAgentSession>)performEndSessionRequest:(OIDServiceConfiguration *)serviceConfiguration
+                                          requestParameters:(EndSessionRequestParameters *)requestParameters
+                                                     result:(FlutterResult)result;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/flutter_appauth/ios/Classes/FlutterAppAuth.h
+++ b/flutter_appauth/ios/Classes/FlutterAppAuth.h
@@ -12,8 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface FlutterAppAuth : NSObject
 
 + (NSMutableDictionary *)processResponses:(OIDTokenResponse*) tokenResponse authResponse:(OIDAuthorizationResponse* _Nullable) authResponse;
-+ (void)finishWithError:(NSString *)errorCode message:(NSString *)message  result:(FlutterResult)result;
-+ (NSString *) formatMessageWithError:(NSString *)messageFormat error:(NSError * _Nullable)error;
++ (void)finishWithError:(NSError * _Nullable)error, errorCode:(NSString *)baseCode, messageFormat:(NSString *)messageFormat, result:(FlutterResult)result;
 
 @end
 

--- a/flutter_appauth/ios/Classes/FlutterAppAuth.m
+++ b/flutter_appauth/ios/Classes/FlutterAppAuth.m
@@ -33,17 +33,30 @@
     if (tokenResponse.scope) {
         [processedResponses setObject:[tokenResponse.scope componentsSeparatedByString: @" "] forKey:@"scopes"];
     }
-    
+
     return processedResponses;
 }
 
-+ (void)finishWithError:(NSString *)errorCode message:(NSString *)message  result:(FlutterResult)result {
++ (void)finishWithError:(NSString *)errorCode message:(NSString *)message result:(FlutterResult)result {
     result([FlutterError errorWithCode:errorCode message:message details:nil]);
 }
 
 + (NSString *) formatMessageWithError:(NSString *)messageFormat error:(NSError * _Nullable)error {
     NSString *formattedMessage = [NSString stringWithFormat:messageFormat, [error localizedDescription]];
     return formattedMessage;
+}
+
++ (NSString *) formatErrorCodeWithError:(NSString *)baseCode error: (NSError * _Nullable)error {
+    if(error == nil) {
+        return baseCode;
+    }
+    return [NSString stringWithFormat:@"%@:%@:%ld", baseCode, error.domain, (long)error.code];
+}
+
++ (void)finishWithError:(NSError * _Nullable)error, errorCode:(NSString *)baseCode, messageFormat:(NSString *)messageFormat, result:(FlutterResult)result;
+    NSString * code = [self formatErrorCodeWithError:baseCode error:error];
+    NSString * message = [self formatMessageWithError:messageFormat error:error];
+    [self finishWithError:code message:message result:result];
 }
 
 @end

--- a/flutter_appauth/ios/Classes/FlutterAppAuth.m
+++ b/flutter_appauth/ios/Classes/FlutterAppAuth.m
@@ -37,23 +37,30 @@
     return processedResponses;
 }
 
-+ (void)finishWithError:(NSString *)errorCode message:(NSString *)message result:(FlutterResult)result {
++ (void)finishWithError:(NSString *)errorCode
+                message:(NSString *)message
+                 result:(FlutterResult)result {
     result([FlutterError errorWithCode:errorCode message:message details:nil]);
 }
 
-+ (NSString *) formatMessageWithError:(NSString *)messageFormat error:(NSError * _Nullable)error {
++ (NSString *) formatMessageWithError:(NSString *)messageFormat
+                                error:(NSError * _Nullable)error {
     NSString *formattedMessage = [NSString stringWithFormat:messageFormat, [error localizedDescription]];
     return formattedMessage;
 }
 
-+ (NSString *) formatErrorCodeWithError:(NSString *)baseCode error: (NSError * _Nullable)error {
++ (NSString *) formatErrorCodeWithError:(NSString *)baseCode
+                                  error: (NSError * _Nullable)error {
     if(error == nil) {
         return baseCode;
     }
     return [NSString stringWithFormat:@"%@:%@:%ld", baseCode, error.domain, (long)error.code];
 }
 
-+ (void)finishWithError:(NSError * _Nullable)error, errorCode:(NSString *)baseCode, messageFormat:(NSString *)messageFormat, result:(FlutterResult)result;
++ (void)finishWithError:(NSError * _Nullable)error
+              errorCode:(NSString *)baseCode
+          messageFormat:(NSString *)messageFormat
+                 result:(FlutterResult)result {
     NSString * code = [self formatErrorCodeWithError:baseCode error:error];
     NSString * message = [self formatMessageWithError:messageFormat error:error];
     [self finishWithError:code message:message result:result];

--- a/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
@@ -98,10 +98,10 @@ AppAuthAuthorization* authorization;
                binaryMessenger:[registrar messenger]];
     FlutterAppauthPlugin* instance = [[FlutterAppauthPlugin alloc] init];
     [registrar addMethodCallDelegate:instance channel:channel];
-    
+
 #if TARGET_OS_OSX
     authorization = [[AppAuthMacOSAuthorization alloc] init];
-    
+
     NSAppleEventManager *appleEventManager = [NSAppleEventManager sharedAppleEventManager];
     [appleEventManager setEventHandler:instance
                            andSelector:@selector(handleGetURLEvent:withReplyEvent:)
@@ -109,7 +109,7 @@ AppAuthAuthorization* authorization;
                             andEventID:kAEGetURL];
 #else
     authorization = [[AppAuthIOSAuthorization alloc] init];
-    
+
     [registrar addApplicationDelegate:instance];
 #endif
 }
@@ -180,8 +180,7 @@ AppAuthAuthorization* authorization;
 }
 
 - (void)finishWithDiscoveryError:(NSError * _Nullable)error result:(FlutterResult)result {
-    NSString *message = [NSString stringWithFormat:DISCOVERY_ERROR_MESSAGE_FORMAT, [error localizedDescription]];
-    [FlutterAppAuth finishWithError:DISCOVERY_ERROR_CODE message:message result:result];
+    [FlutterAppAuth finishWithError:error errorCode:DISCOVERY_ERROR_CODE messageFormat:DISCOVERY_ERROR_MESSAGE_FORMAT result:result];
 }
 
 
@@ -201,7 +200,7 @@ AppAuthAuthorization* authorization;
         [self performTokenRequest:serviceConfiguration requestParameters:requestParameters result:result];
     } else if (requestParameters.discoveryUrl) {
         NSURL *discoveryUrl = [NSURL URLWithString:requestParameters.discoveryUrl];
-        
+
         [OIDAuthorizationService discoverServiceConfigurationForDiscoveryURL:discoveryUrl
                                                                   completion:^(OIDServiceConfiguration *_Nullable configuration,
                                                                                NSError *_Nullable error) {
@@ -209,7 +208,7 @@ AppAuthAuthorization* authorization;
                 [self finishWithDiscoveryError:error result:result];
                 return;
             }
-            
+
             [self performTokenRequest:configuration requestParameters:requestParameters result:result];
         }];
     } else {
@@ -221,7 +220,7 @@ AppAuthAuthorization* authorization;
                 [self finishWithDiscoveryError:error result:result];
                 return;
             }
-            
+
             [self performTokenRequest:configuration requestParameters:requestParameters result:result];
         }];
     }
@@ -234,7 +233,7 @@ AppAuthAuthorization* authorization;
         _currentAuthorizationFlow = [authorization performEndSessionRequest:serviceConfiguration requestParameters:requestParameters result:result];
     } else if (requestParameters.discoveryUrl) {
         NSURL *discoveryUrl = [NSURL URLWithString:requestParameters.discoveryUrl];
-        
+
         [OIDAuthorizationService discoverServiceConfigurationForDiscoveryURL:discoveryUrl
                                                                   completion:^(OIDServiceConfiguration *_Nullable configuration,
                                                                                NSError *_Nullable error) {
@@ -242,7 +241,7 @@ AppAuthAuthorization* authorization;
                 [self finishWithDiscoveryError:error result:result];
                 return;
             }
-            
+
             self->_currentAuthorizationFlow = [authorization performEndSessionRequest:configuration requestParameters:requestParameters result:result];
         }];
     } else {
@@ -254,7 +253,7 @@ AppAuthAuthorization* authorization;
                 [self finishWithDiscoveryError:error result:result];
                 return;
             }
-            
+
             self->_currentAuthorizationFlow = [authorization performEndSessionRequest:configuration requestParameters:requestParameters result:result];
         }];
     }
@@ -276,10 +275,10 @@ AppAuthAuthorization* authorization;
                                         callback:^(OIDTokenResponse *_Nullable response,
                                                    NSError *_Nullable error) {
         if (response) {
-            result([FlutterAppAuth processResponses:response authResponse:nil]);                                           } else {
-                NSString *message = [NSString stringWithFormat:TOKEN_ERROR_MESSAGE_FORMAT, [error localizedDescription]];
-                [FlutterAppAuth finishWithError:TOKEN_ERROR_CODE message:message result:result];
-            }
+            result([FlutterAppAuth processResponses:response authResponse:nil]);
+        } else {
+            [FlutterAppAuth finishWithError:error errorCode:TOKEN_ERROR_CODE messageFormat:TOKEN_ERROR_MESSAGE_FORMAT result:result];
+        }
     }];
 }
 
@@ -291,7 +290,7 @@ AppAuthAuthorization* authorization;
         _currentAuthorizationFlow = nil;
         return YES;
     }
-    
+
     return NO;
 }
 

--- a/flutter_appauth/macos/Classes/AppAuthMacOSAuthorization.m
+++ b/flutter_appauth/macos/Classes/AppAuthMacOSAuthorization.m
@@ -26,9 +26,8 @@
                                                                                                                   NSError *_Nullable error) {
             if(authState) {
                 result([FlutterAppAuth processResponses:authState.lastTokenResponse authResponse:authState.lastAuthorizationResponse]);
-                
             } else {
-                [FlutterAppAuth finishWithError:AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE message:[FlutterAppAuth formatMessageWithError:AUTHORIZE_ERROR_MESSAGE_FORMAT error:error] result:result];
+                [FlutterAppAuth finishWithError:error errorCode:AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE messageFormat:AUTHORIZE_ERROR_MESSAGE_FORMAT result:result];
             }
         }];
     } else {
@@ -42,7 +41,7 @@
                 [processedResponse setObject:authorizationResponse.request.nonce forKey:@"nonce"];
                 result(processedResponse);
             } else {
-                [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE message:[FlutterAppAuth formatMessageWithError:AUTHORIZE_ERROR_MESSAGE_FORMAT error:error] result:result];
+                [FlutterAppAuth finishWithError:error errorCode:AUTHORIZE_ERROR_CODE messageFormat:AUTHORIZE_ERROR_MESSAGE_FORMAT result:result];
             }
         }];
     }
@@ -50,17 +49,16 @@
 
 - (id<OIDExternalUserAgentSession>)performEndSessionRequest:(OIDServiceConfiguration *)serviceConfiguration requestParameters:(EndSessionRequestParameters *)requestParameters result:(FlutterResult)result {
     NSURL *postLogoutRedirectURL = requestParameters.postLogoutRedirectUrl ? [NSURL URLWithString:requestParameters.postLogoutRedirectUrl] : nil;
-    
+
     OIDEndSessionRequest *endSessionRequest = requestParameters.state ? [[OIDEndSessionRequest alloc] initWithConfiguration:serviceConfiguration idTokenHint:requestParameters.idTokenHint postLogoutRedirectURL:postLogoutRedirectURL
                                                                                                                       state:requestParameters.state additionalParameters:requestParameters.additionalParameters] :[[OIDEndSessionRequest alloc] initWithConfiguration:serviceConfiguration idTokenHint:requestParameters.idTokenHint postLogoutRedirectURL:postLogoutRedirectURL
                                                                                                                                                                                                                                                  additionalParameters:requestParameters.additionalParameters];
-    
+
     NSWindow *keyWindow = [[NSApplication sharedApplication] keyWindow];
     id<OIDExternalUserAgent> externalUserAgent = [self userAgentWithPresentingWindow:keyWindow useEphemeralSession:requestParameters.preferEphemeralSession];
     return [OIDAuthorizationService presentEndSessionRequest:endSessionRequest externalUserAgent:externalUserAgent callback:^(OIDEndSessionResponse * _Nullable endSessionResponse, NSError * _Nullable error) {
         if(!endSessionResponse) {
-            NSString *message = [NSString stringWithFormat:END_SESSION_ERROR_MESSAGE_FORMAT, [error localizedDescription]];
-            [FlutterAppAuth finishWithError:END_SESSION_ERROR_CODE message:message result:result];
+            [FlutterAppAuth finishWithError:error errorCode:END_SESSION_ERROR_CODE messageFormat:END_SESSION_ERROR_MESSAGE_FORMAT result:result];
             return;
         }
         NSMutableDictionary *processedResponse = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION
An implementation for the issue https://github.com/MaikuB/flutter_appauth/issues/394

It employs a new code format: `<existing code>:<domain/type>:<code>`

This might need to be considered as Breaking Changes, as it breaks the code that checks code right now. But it can be easily fixed:

For existing code:

```dart
try { 
  // calling appauth
} on PlatformException catch(ex) {
  if (ex.code == "authorize_and_exchange_code_failed") {
    // handle error
  }
}
```
It can be upgraded as 
```dart
try { 
  // calling appauth
} on PlatformException catch(ex) {
  if (ex.code.startsWith("authorize_and_exchange_code_failed:")) {
    // handle error
  }
}
```

For user cancelled the webview for auth, the error could be 
* iOS: `authorize_and_exchange_code_failed:org.openid.appauth.general:-3`
* Android: `authorize_and_exchange_code_failed:GENERAL_ERROR:1`
