### PR TITLE
[flutter_appauth][flutter_appauth_platform_interface] Ability to programmatically close login flow in iOS

### DIFF
--- a/flutter_appauth/ios/Classes/FlutterAppAuth.h
+++ b/flutter_appauth/ios/Classes/FlutterAppAuth.h
@@ -30,6 +30,7 @@ static NSString *const DISCOVERY_ERROR_MESSAGE_FORMAT = @"Error retrieving disco
 static NSString *const TOKEN_ERROR_MESSAGE_FORMAT = @"Failed to get token: %@";
 static NSString *const AUTHORIZE_ERROR_MESSAGE_FORMAT = @"Failed to authorize: %@";
 static NSString *const END_SESSION_ERROR_MESSAGE_FORMAT = @"Failed to end session: %@";
+static NSString *const CANCEL_AUTHORIZATION_METHOD = @"cancelAuthorization";
 
 @interface EndSessionRequestParameters : NSObject
 @property(nonatomic, strong) NSString *idTokenHint;
@@ -45,7 +46,7 @@ static NSString *const END_SESSION_ERROR_MESSAGE_FORMAT = @"Failed to end sessio
 @interface AppAuthAuthorization : NSObject
 
 - (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(NSString*)nonce;
-
+- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(NSString*)nonce setGlobal:(void(*)(NSObject<OIDExternalUserAgent>* agent, FlutterResult result))setGlobal;
 - (id<OIDExternalUserAgentSession>)performEndSessionRequest:(OIDServiceConfiguration *)serviceConfiguration requestParameters:(EndSessionRequestParameters *)requestParameters result:(FlutterResult)result;
 
 @end

--- a/flutter_appauth/lib/src/flutter_appauth.dart
+++ b/flutter_appauth/lib/src/flutter_appauth.dart
@@ -25,6 +25,6 @@ class FlutterAppAuth {
 
   /// New method to close auth browser window
   Future<bool> cancelAuthorization() {
-    return FlutterAppAuthPlatformIos.instance.cancelAuthorization();
+    return FlutterAppAuthPlatform.instance.cancelAuthorization();
   }
 }

--- a/flutter_appauth/lib/src/flutter_appauth.dart
+++ b/flutter_appauth/lib/src/flutter_appauth.dart
@@ -22,4 +22,9 @@ class FlutterAppAuth {
   Future<EndSessionResponse?> endSession(EndSessionRequest request) {
     return FlutterAppAuthPlatform.instance.endSession(request);
   }
+
+  /// New method to close auth browser window
+  Future<bool> cancelAuthorization() {
+    return FlutterAppAuthPlatformIos.instance.cancelAuthorization();
+  }
 }

--- a/flutter_appauth_platform_interface/lib/src/flutter_appauth_platform.dart
+++ b/flutter_appauth_platform_interface/lib/src/flutter_appauth_platform.dart
@@ -50,4 +50,9 @@ abstract class FlutterAppAuthPlatform extends PlatformInterface {
   Future<EndSessionResponse?> endSession(EndSessionRequest request) {
     throw UnimplementedError('endSession() has not been implemented');
   }
+
+  /// New method to close auth browser window
+  Future<bool> cancelAuthorization() {
+    throw UnimplementedError('cancelAuthorization() has not been implemented');
+  }
 }

--- a/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
@@ -82,4 +82,14 @@ class MethodChannelFlutterAppAuth extends FlutterAppAuthPlatform {
     }
     return EndSessionResponse(result['state']);
   }
+
+  @override
+  Future<bool> cancelAuthorization() async {
+    final Map<dynamic, dynamic>? result =
+        await _channel.invokeMethod('cancelAuthorization');
+    if (result == null) {
+      return false;
+    }
+    return result['success'] ?? true;
+  }
 }


### PR DESCRIPTION
I needed a way to programmatically close the login flow. In android this was could be done using Navigator.pop, but for iOS, this was not possible.

This PR saves the OIDExternalUserAgent and FlutterResult in FlutterAppAuthPlugin.m so that a new method call (`cancelAuthorization`) can later close the login window and return the result.