### PR TITLE
[flutter_appauth] code_challenge explanation added in the example class

### DIFF
--- a/flutter_appauth/example/lib/main.dart
+++ b/flutter_appauth/example/lib/main.dart
@@ -209,7 +209,13 @@ class _MyAppState extends State<MyApp> {
   Future<void> _signInWithNoCodeExchange() async {
     try {
       _setBusyState();
-      // use the discovery endpoint to find the configuration
+       /* 
+         The discovery endpoint (_discoveryUrl) is used to find the configuration.
+         The code challenge generation can be checked here > https://github.com/MaikuB/flutter_appauth/search?q=challenge.
+         The code challenge is generated from the code verifier and only the code verifier is included in the result.
+         This because to get the token in the method _exchangeCode (see above) we need only the code verifier and the authorization code
+         according to the spec https://www.rfc-editor.org/rfc/rfc7636 page 9 section 4.5.
+      */
       final AuthorizationResponse? result = await _appAuth.authorize(
         AuthorizationRequest(_clientId, _redirectUrl,
             discoveryUrl: _discoveryUrl, scopes: _scopes, loginHint: 'bob'),


### PR DESCRIPTION
Pulled last changes in master and added an additional line to explain where the code challenge generation can be checked

As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_appauth])