### PR TITLE
[flutter_appauth] use initWithPresentingWindow to fix deprecation warning

### DIFF
--- a/flutter_appauth/macos/Classes/AppAuthMacOSAuthorization.m
+++ b/flutter_appauth/macos/Classes/AppAuthMacOSAuthorization.m
@@ -73,7 +73,7 @@
     if (useEphemeralSession) {
         return [[OIDExternalUserAgentMacNoSSO alloc] initWithPresentingWindow:presentingWindow];
     }
-    return [[OIDExternalUserAgentMac alloc] init];
+    return [[OIDExternalUserAgentMac alloc] initWithPresentingWindow:presentingWindow];
 }
 
 @end


### PR DESCRIPTION
[flutter_appauth] fix MacOs auth. Without that it opens regular Safari browser and can't return back.

