### PR TITLE
[flutter_appauth] - Update AppDelegate.swift in the example App

### DIFF
--- a/flutter_appauth/example/ios/Runner/AppDelegate.swift
+++ b/flutter_appauth/example/ios/Runner/AppDelegate.swift
@@ -7,6 +7,10 @@ import Flutter
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    //Without this line of code the access token returned from the 
+    //webview is stored in the cache.db file of the IOS App
+    //For more information have a look at > https://kunalgupta1508.medium.com/data-leakage-with-cache-db-2d311582cf23
+    URLCache.shared = URLCache(memoryCapacity: 0, diskCapacity: 0, diskPath: nil)
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }


### PR DESCRIPTION
I discover this potential data leak while playing with an IOS implementation of your library. You can double check..

- Open Xcode and download the container of the Application after a login is performed with your library. 
- You will find the access token stored in the cache.db file, in a table called: cfurl_cache_receiver_data

<img width="1537" alt="MicrosoftTeams-image (7)" src="https://github.com/MaikuB/flutter_appauth/assets/51212757/ae39ce24-c9e4-420f-a53c-0f721490a4c9">
