### PR TITLE
[flutter_appauth] Catch native ActivityNotFoundException

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -348,8 +348,13 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         }
 
         AuthorizationService authorizationService = allowInsecureConnections ? insecureAuthorizationService : defaultAuthorizationService;
-        Intent authIntent = authorizationService.getAuthorizationRequestIntent(authRequestBuilder.build());
-        mainActivity.startActivityForResult(authIntent, exchangeCode ? RC_AUTH_EXCHANGE_CODE : RC_AUTH);
+
+        try {
+            Intent authIntent = authorizationService.getAuthorizationRequestIntent(authRequestBuilder.build());
+            mainActivity.startActivityForResult(authIntent, exchangeCode ? RC_AUTH_EXCHANGE_CODE : RC_AUTH);
+        } catch (Exception ex) {
+            finishWithError(exchangeCode ? AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE : AUTHORIZE_ERROR_CODE, ex.toString(), getCauseFromException(ex));
+        }
     }
 
     private void performTokenRequest(AuthorizationServiceConfiguration serviceConfiguration, TokenRequestParameters tokenRequestParameters) {

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -1,6 +1,7 @@
 package io.crossingthestreams.flutterappauth;
 
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -56,6 +57,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     private static final String END_SESSION_ERROR_CODE = "end_session_failed";
     private static final String NULL_INTENT_ERROR_CODE = "null_intent";
     private static final String INVALID_CLAIMS_ERROR_CODE = "invalid_claims";
+    private static final String NO_BROWSER_AVAILABLE_ERROR_CODE = "no_browser_available";
 
     private static final String DISCOVERY_ERROR_MESSAGE_FORMAT = "Error retrieving discovery document: [error: %s, description: %s]";
     private static final String TOKEN_ERROR_MESSAGE_FORMAT = "Failed to get token: [error: %s, description: %s]";
@@ -63,6 +65,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     private static final String END_SESSION_ERROR_MESSAGE_FORMAT = "Failed to end session: [error: %s, description: %s]";
 
     private static final String NULL_INTENT_ERROR_FORMAT = "Failed to authorize: Null intent received";
+    private static final String NO_BROWSER_AVAILABLE_ERROR_FORMAT = "Failed to authorize: No suitable browser is available";
 
     private final int RC_AUTH_EXCHANGE_CODE = 65030;
     private final int RC_AUTH = 65031;
@@ -352,8 +355,8 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         try {
             Intent authIntent = authorizationService.getAuthorizationRequestIntent(authRequestBuilder.build());
             mainActivity.startActivityForResult(authIntent, exchangeCode ? RC_AUTH_EXCHANGE_CODE : RC_AUTH);
-        } catch (Exception ex) {
-            finishWithError(exchangeCode ? AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE : AUTHORIZE_ERROR_CODE, ex.toString(), getCauseFromException(ex));
+        } catch (ActivityNotFoundException ex) {
+            finishWithError(NO_BROWSER_AVAILABLE_ERROR_CODE, NO_BROWSER_AVAILABLE_ERROR_FORMAT, getCauseFromException(ex));
         }
     }
 


### PR DESCRIPTION
Currently, if there are no browser installed on the device, the underlying plugin AppAuth-Android will throw an ActivityNotFoundException which crashes the Flutter application. This was for instance reported here: https://github.com/MaikuB/flutter_appauth/issues/168

You can reproduce the error by running the example app on any emulator without any installed browsers (disable the default Chrome in Settings - Apps - Chrome) and trying to login.

This fixes the error by catching the ActivityNotFoundException and returning a PlattformException.
