### PR TITLE
[flutter_appauth] Fix for logout crash while app is on background

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -493,15 +493,20 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
             return true;
         }
         if (requestCode == RC_END_SESSION) {
-            final EndSessionResponse endSessionResponse = EndSessionResponse.fromIntent(intent);
-            AuthorizationException ex = AuthorizationException.fromIntent(intent);
-            if (ex != null) {
-                finishWithEndSessionError(ex);
+            if (intent == null) {
+                finishWithError(NULL_INTENT_ERROR_CODE, NULL_INTENT_ERROR_FORMAT, null);
             } else {
-                Map<String, Object> responseMap = new HashMap<>();
-                responseMap.put("state", endSessionResponse.state);
-                finishWithSuccess(responseMap);
+                final EndSessionResponse endSessionResponse = EndSessionResponse.fromIntent(intent);
+                AuthorizationException ex = AuthorizationException.fromIntent(intent);
+                if (ex != null) {
+                    finishWithEndSessionError(ex);
+                } else {
+                    Map<String, Object> responseMap = new HashMap<>();
+                    responseMap.put("state", endSessionResponse.state);
+                    finishWithSuccess(responseMap);
+                }
             }
+            return true;
         }
         return false;
     }


### PR DESCRIPTION
on Android Ii user does logout and while logging out user closes the browser and go background and come back, the app crashes. It happens because flutter activity waits for intent not to be null, but it is null. We need to add null check on activity result method on Android. 

Related issue: https://github.com/MaikuB/flutter_appauth/issues/459#issuecomment-1865485929