### PR TITLE
[flutter_appauth] Feature: Android pendingOperation callback

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -467,7 +467,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
             pendingOperation.result.success(data);
             pendingOperation = null;
         } else {
-            channel.invokeMethod(HAS_PENDING_OPERATION, null);
+            channel.invokeMethod(HAS_PENDING_OPERATION, data);
         }
     }
 
@@ -476,7 +476,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
             pendingOperation.result.error(errorCode, errorMessage, errorDetails);
             pendingOperation = null;
         } else {
-            channel.invokeMethod(HAS_PENDING_OPERATION, null);
+            channel.invokeMethod(HAS_PENDING_OPERATION, errorCode);
         }
     }
 

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -80,7 +80,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     private AuthorizationService defaultAuthorizationService;
     private AuthorizationService insecureAuthorizationService;
 
-    private String methodChannelName = "crossingthestreams.io/flutter_appauth";
+    private final String methodChannelName = "crossingthestreams.io/flutter_appauth";
 
     private MethodChannel channel;
     


### PR DESCRIPTION
As i mentioned [here](https://github.com/MaikuB/flutter_appauth/issues/495) android has a lifecycle issue. In this pr i tried to solved it simply by adding HAS_PENDING_OPERATION invoke method for this situation.

I think it can be solved clearly with adding a callback method maybe but i didn't want to touch the code base too much and just focused to solve it simply.

In the app side i just did this quickly and solve the problem
```dart
 final MethodChannel methodChannel = const MethodChannel('crossingthestreams.io/flutter_appauth');

  @override
  void initState() {
    super.initState();
    methodChannel.setMethodCallHandler((methodCall) async {
      if (methodCall.method == 'hasPendingOperation') {
        final arguments = methodCall.arguments;
        if (arguments case {'accessToken': String _}) {
          unawaited(context.read<AuthenticationCubit>().login());
        }
      }
    });
  }
```