### PR TITLE
[flutter_appauth] remove obsolete analysis_options comment

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -28,9 +28,6 @@ analyzer:
     missing_return: warning
     # allow having TODOs in the code
     todo: ignore
-    # Ignore analyzer hints for updating pubspecs when using Future or
-    # Stream and not importing dart:async
-    # Please see https://github.com/flutter/flutter/pull/24528 for details.
   exclude:
     - "bin/cache/**"
     # the following two are relative to the stocks example and the flutter package respectively


### PR DESCRIPTION
the corresponding option was removed here: https://github.com/MaikuB/flutter_appauth/commit/1d821e3689f784c02a1801947a112cee38c74221#diff-9a967a7bb0393381dfdf9cce102a9cea39146829ab8b38e983d54ac8827486bcL34