### PR TITLE
[flutter_appauth_platform_interface] made FlutterAppAuthPlatformErrorDetails constructor parameters optional

### DIFF
--- a/flutter_appauth_platform_interface/CHANGELOG.md
+++ b/flutter_appauth_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [7.0.1]
+
+* Updated `FlutterAppAuthPlatformErrorDetails` so all the constructor parameters are optional instead of being mandatory through the `required` keyword. This should be a non-breaking change since all the parameters were nullable. Change was done to make code using the class easier to use e.g. when writing tests
+
 ## [7.0.0]
 
 * **Breaking change** Bumped minimum Flutter and Dart SDK constraints to 3.13.0 and 3.1.0 respectively

--- a/flutter_appauth_platform_interface/lib/src/errors.dart
+++ b/flutter_appauth_platform_interface/lib/src/errors.dart
@@ -4,14 +4,14 @@ import 'package:flutter/services.dart';
 /// platform's AppAuth SDK
 class FlutterAppAuthPlatformErrorDetails {
   FlutterAppAuthPlatformErrorDetails({
-    required this.type,
-    required this.code,
-    required this.error,
-    required this.errorDescription,
-    required this.errorUri,
-    required this.domain,
-    required this.rootCauseDebugDescription,
-    required this.errorDebugDescription,
+    this.type,
+    this.code,
+    this.error,
+    this.errorDescription,
+    this.errorUri,
+    this.domain,
+    this.rootCauseDebugDescription,
+    this.errorDebugDescription,
   });
 
   /// The type of error.

--- a/flutter_appauth_platform_interface/pubspec.yaml
+++ b/flutter_appauth_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_appauth_platform_interface
 description: A common platform interface for the flutter_appauth plugin.
-version: 7.0.0
+version: 7.0.1
 homepage: https://github.com/MaikuB/flutter_appauth/tree/master/flutter_appauth_platform_interface
 
 environment:


### PR DESCRIPTION
Removed the need for having the parameters of the `FlutterAppAuthPlatformErrorDetails` constructor being required as they're nullable