### PR TITLE
Implement support for SFSafariController on iOS

### DIFF
--- a/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.h
+++ b/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.h
@@ -1,6 +1,7 @@
 #import <AppAuth/AppAuth.h>
 #import <Flutter/Flutter.h>
 #import "OIDExternalUserAgentIOSNoSSO.h"
+#import "OIDExternalUserAgentIOSSafariViewController.h"
 #import "FlutterAppAuth.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/flutter_appauth/ios/Classes/FlutterAppAuth.h
+++ b/flutter_appauth/ios/Classes/FlutterAppAuth.h
@@ -39,12 +39,12 @@ static NSString *const END_SESSION_ERROR_MESSAGE_FORMAT = @"Failed to end sessio
 @property(nonatomic, strong) NSString *discoveryUrl;
 @property(nonatomic, strong) NSDictionary *serviceConfigurationParameters;
 @property(nonatomic, strong) NSDictionary *additionalParameters;
-@property(nonatomic, readwrite) BOOL preferEphemeralSession;
+@property(nonatomic, strong) NSString *preferredExternalAgent;
 @end
 
 @interface AppAuthAuthorization : NSObject
 
-- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(NSString*)nonce;
+- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferredExternalAgent:(NSString*)preferredExternalAgent result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(NSString*)nonce;
 
 - (id<OIDExternalUserAgentSession>)performEndSessionRequest:(OIDServiceConfiguration *)serviceConfiguration requestParameters:(EndSessionRequestParameters *)requestParameters result:(FlutterResult)result;
 

--- a/flutter_appauth/ios/Classes/FlutterAppAuth.m
+++ b/flutter_appauth/ios/Classes/FlutterAppAuth.m
@@ -96,7 +96,7 @@
 
 @implementation AppAuthAuthorization
 
-- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(NSString*)nonce {
+- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferredExternalAgent:(NSString*)preferredExternalAgent result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(NSString*)nonce {
     return nil;
 }
 

--- a/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
@@ -28,7 +28,7 @@
 @property(nonatomic, strong) NSArray *scopes;
 @property(nonatomic, strong) NSDictionary *serviceConfigurationParameters;
 @property(nonatomic, strong) NSDictionary *additionalParameters;
-@property(nonatomic, readwrite) BOOL preferEphemeralSession;
+@property(nonatomic, strong) NSString *preferredExternalAgent;
 
 @end
 
@@ -47,7 +47,7 @@
     _scopes = [ArgumentProcessor processArgumentValue:arguments withKey:@"scopes"];
     _serviceConfigurationParameters = [ArgumentProcessor processArgumentValue:arguments withKey:@"serviceConfiguration"];
     _additionalParameters = [ArgumentProcessor processArgumentValue:arguments withKey:@"additionalParameters"];
-    _preferEphemeralSession = [[ArgumentProcessor processArgumentValue:arguments withKey:@"preferEphemeralSession"] isEqual:@YES];
+    _preferredExternalAgent = [ArgumentProcessor processArgumentValue:arguments withKey:@"preferredExternalAgent"];
 }
 
 - (id)initWithArguments:(NSDictionary *)arguments {
@@ -82,7 +82,7 @@
     _discoveryUrl = [ArgumentProcessor processArgumentValue:arguments withKey:@"discoveryUrl"];
     _serviceConfigurationParameters = [ArgumentProcessor processArgumentValue:arguments withKey:@"serviceConfiguration"];
     _additionalParameters = [ArgumentProcessor processArgumentValue:arguments withKey:@"additionalParameters"];
-    _preferEphemeralSession = [[ArgumentProcessor processArgumentValue:arguments withKey:@"preferEphemeralSession"] isEqual:@YES];
+    _preferredExternalAgent = [ArgumentProcessor processArgumentValue:arguments withKey:@"preferredExternalAgent"];
     return self;
 }
 @end
@@ -149,7 +149,7 @@ AppAuthAuthorization* authorization;
 
     if(requestParameters.serviceConfigurationParameters != nil) {
         OIDServiceConfiguration *serviceConfiguration = [self processServiceConfigurationParameters:requestParameters.serviceConfigurationParameters];
-        _currentAuthorizationFlow = [authorization performAuthorization:serviceConfiguration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode nonce:requestParameters.nonce];
+        _currentAuthorizationFlow = [authorization performAuthorization:serviceConfiguration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferredExternalAgent:requestParameters.preferredExternalAgent result:result exchangeCode:exchangeCode nonce:requestParameters.nonce];
     } else if (requestParameters.discoveryUrl) {
         NSURL *discoveryUrl = [NSURL URLWithString:requestParameters.discoveryUrl];
         [OIDAuthorizationService discoverServiceConfigurationForDiscoveryURL:discoveryUrl
@@ -161,7 +161,7 @@ AppAuthAuthorization* authorization;
                 return;
             }
 
-            self->_currentAuthorizationFlow = [authorization performAuthorization:configuration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode nonce:requestParameters.nonce];
+            self->_currentAuthorizationFlow = [authorization performAuthorization:configuration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferredExternalAgent:requestParameters.preferredExternalAgent result:result exchangeCode:exchangeCode nonce:requestParameters.nonce];
         }];
     } else {
         NSURL *issuerUrl = [NSURL URLWithString:requestParameters.issuer];
@@ -174,7 +174,7 @@ AppAuthAuthorization* authorization;
                 return;
             }
 
-            self->_currentAuthorizationFlow = [authorization performAuthorization:configuration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode nonce:requestParameters.nonce];
+            self->_currentAuthorizationFlow = [authorization performAuthorization:configuration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferredExternalAgent:requestParameters.preferredExternalAgent result:result exchangeCode:exchangeCode nonce:requestParameters.nonce];
         }];
     }
 }

--- a/flutter_appauth/ios/Classes/OIDExternalUserAgentIOSSafariViewController.h
+++ b/flutter_appauth/ios/Classes/OIDExternalUserAgentIOSSafariViewController.h
@@ -1,0 +1,68 @@
+/*! @file OIDExternalUserAgentIOSSafariViewController.h
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2018 Google Inc. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import "OIDExternalUserAgentIOSSafariViewController.h"
+#import "OIDExternalUserAgent.h"
+#import "OIDExternalUserAgentIOS.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/*! @brief Allows library consumers to bootstrap an @c SFSafariViewController as they see fit.
+    @remarks Useful for customizing tint colors and presentation styles.
+ */
+@protocol OIDSafariViewControllerFactory
+
+/*! @brief Creates and returns a new @c SFSafariViewController.
+    @param URL The URL which the @c SFSafariViewController should load initially.
+ */
+- (SFSafariViewController *)safariViewControllerWithURL:(NSURL *)URL;
+
+@end
+
+/*! @brief A special-case iOS external user-agent that always uses
+        \SFSafariViewController (on iOS 9+). Most applications should use
+        the more generic @c OIDExternalUserAgentIOS to get the default
+        AppAuth user-agent handling with the benefits of Single Sign-on (SSO)
+        for all supported versions of iOS.
+ */
+@interface OIDExternalUserAgentIOSSafariViewController : NSObject<OIDExternalUserAgent>
+
+/*! @brief Allows library consumers to change the @c OIDSafariViewControllerFactory used to create
+        new instances of @c SFSafariViewController.
+    @remarks Useful for customizing tint colors and presentation styles.
+    @param factory The @c OIDSafariViewControllerFactory to use for creating new instances of
+        @c SFSafariViewController.
+ */
++ (void)setSafariViewControllerFactory:(id<OIDSafariViewControllerFactory>)factory;
+
+/*! @internal
+    @brief Unavailable. Please use @c initWithPresentingViewController:
+ */
+- (nonnull instancetype)init NS_UNAVAILABLE;
+
+/*! @brief The designated initializer.
+    @param presentingViewController The view controller from which to present the
+        \SFSafariViewController.
+ */
+- (nullable instancetype)initWithPresentingViewController:
+    (UIViewController *)presentingViewController
+            NS_DESIGNATED_INITIALIZER;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/flutter_appauth/ios/Classes/OIDExternalUserAgentIOSSafariViewController.m
+++ b/flutter_appauth/ios/Classes/OIDExternalUserAgentIOSSafariViewController.m
@@ -1,0 +1,173 @@
+/*! @file OIDExternalUserAgentIOSSafariViewController.m
+    @brief AppAuth iOS SDK
+    @copyright
+        Copyright 2018 Google Inc. All Rights Reserved.
+    @copydetails
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+ */
+
+#import "OIDExternalUserAgentIOSSafariViewController.h"
+
+#import <SafariServices/SafariServices.h>
+
+#import "OIDErrorUtilities.h"
+#import "OIDExternalUserAgentSession.h"
+#import "OIDExternalUserAgentRequest.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** @brief The global/shared Safari view controller factory. Responsible for creating all new
+ instances of @c SFSafariViewController.
+ */
+static id<OIDSafariViewControllerFactory> __nullable gSafariViewControllerFactory;
+
+/** @brief The default @c OIDSafariViewControllerFactory which creates new instances of
+        @c SFSafariViewController using known best practices.
+ */
+@interface OIDDefaultSafariViewControllerFactory : NSObject<OIDSafariViewControllerFactory>
+@end
+
+@interface OIDExternalUserAgentIOSSafariViewController ()<SFSafariViewControllerDelegate>
+@end
+
+@implementation OIDExternalUserAgentIOSSafariViewController {
+    UIViewController *_presentingViewController;
+
+    BOOL _externalUserAgentFlowInProgress;
+    __weak id<OIDExternalUserAgentSession> _session;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+    __weak SFSafariViewController *_safariVC;
+#pragma clang diagnostic pop
+}
+
+/** @brief Obtains the current @c OIDSafariViewControllerFactory; creating a new default instance if
+        required.
+ */
++ (id<OIDSafariViewControllerFactory>)safariViewControllerFactory {
+    if (!gSafariViewControllerFactory) {
+        gSafariViewControllerFactory = [[OIDDefaultSafariViewControllerFactory alloc] init];
+    }
+    return gSafariViewControllerFactory;
+}
+
++ (void)setSafariViewControllerFactory:(id<OIDSafariViewControllerFactory>)factory {
+    NSAssert(factory, @"Parameter: |factory| must be non-nil.");
+    gSafariViewControllerFactory = factory;
+}
+
+- (nullable instancetype)initWithPresentingViewController:
+        (UIViewController *)presentingViewController {
+    self = [super init];
+    if (self) {
+        _presentingViewController = presentingViewController;
+    }
+    return self;
+}
+
+- (BOOL)presentExternalUserAgentRequest:(id<OIDExternalUserAgentRequest>)request
+                                session:(id<OIDExternalUserAgentSession>)session {
+    if (_externalUserAgentFlowInProgress) {
+        // TODO: Handle errors as authorization is already in progress.
+        return NO;
+    }
+
+    _externalUserAgentFlowInProgress = YES;
+    _session = session;
+    BOOL openedSafari = NO;
+    NSURL *requestURL = [request externalUserAgentRequestURL];
+
+    if (@available(iOS 9.0, *)) {
+        SFSafariViewController *safariVC =
+                [[[self class] safariViewControllerFactory] safariViewControllerWithURL:requestURL];
+        safariVC.delegate = self;
+        safariVC.modalPresentationStyle = UIModalPresentationFormSheet;
+        _safariVC = safariVC;
+        [_presentingViewController presentViewController:safariVC animated:YES completion:nil];
+        openedSafari = YES;
+    } else {
+        openedSafari = [[UIApplication sharedApplication] openURL:requestURL];
+    }
+
+    if (!openedSafari) {
+        [self cleanUp];
+        NSError *safariError = [OIDErrorUtilities errorWithCode:OIDErrorCodeSafariOpenError
+                                                underlyingError:nil
+                                                    description:@"Unable to open Safari."];
+        [session failExternalUserAgentFlowWithError:safariError];
+    }
+    return openedSafari;
+}
+
+- (void)dismissExternalUserAgentAnimated:(BOOL)animated completion:(void (^)(void))completion {
+    if (!_externalUserAgentFlowInProgress) {
+        // Ignore this call if there is no authorization flow in progress.
+        return;
+    }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+    SFSafariViewController *safariVC = _safariVC;
+#pragma clang diagnostic pop
+
+    [self cleanUp];
+
+    if (@available(iOS 9.0, *)) {
+        if (safariVC) {
+            [safariVC dismissViewControllerAnimated:YES completion:completion];
+        } else {
+            if (completion) completion();
+        }
+    } else {
+        if (completion) completion();
+    }
+}
+
+- (void)cleanUp {
+    // The weak references to |_safariVC| and |_session| are set to nil to avoid accidentally using
+    // them while not in an authorization flow.
+    _safariVC = nil;
+    _session = nil;
+    _externalUserAgentFlowInProgress = NO;
+}
+
+#pragma mark - SFSafariViewControllerDelegate
+
+- (void)safariViewControllerDidFinish:(SFSafariViewController *)controller NS_AVAILABLE_IOS(9.0) {
+    if (controller != _safariVC) {
+        // Ignore this call if the safari view controller do not match.
+        return;
+    }
+    if (!_externalUserAgentFlowInProgress) {
+        // Ignore this call if there is no authorization flow in progress.
+        return;
+    }
+    id<OIDExternalUserAgentSession> session = _session;
+    [self cleanUp];
+    NSError *error = [OIDErrorUtilities errorWithCode:OIDErrorCodeProgramCanceledAuthorizationFlow
+                                      underlyingError:nil
+                                          description:nil];
+    [session failExternalUserAgentFlowWithError:error];
+}
+
+@end
+
+@implementation OIDDefaultSafariViewControllerFactory
+
+- (SFSafariViewController *)safariViewControllerWithURL:(NSURL *)URL NS_AVAILABLE_IOS(9.0) {
+    SFSafariViewController *safariViewController =
+            [[SFSafariViewController alloc] initWithURL:URL entersReaderIfAvailable:NO];
+    return safariViewController;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/flutter_appauth/lib/flutter_appauth.dart
+++ b/flutter_appauth/lib/flutter_appauth.dart
@@ -7,6 +7,7 @@ export 'package:flutter_appauth_platform_interface/flutter_appauth_platform_inte
         AuthorizationTokenResponse,
         EndSessionRequest,
         EndSessionResponse,
+        ExternalAgentType,
         FlutterAppAuthOAuthError,
         FlutterAppAuthPlatformErrorDetails,
         FlutterAppAuthUserCancelledException,

--- a/flutter_appauth/macos/Classes/AppAuthMacOSAuthorization.m
+++ b/flutter_appauth/macos/Classes/AppAuthMacOSAuthorization.m
@@ -2,7 +2,7 @@
 
 @implementation AppAuthMacOSAuthorization
 
-- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(NSString*)nonce {
+- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferredExternalAgent:(NSString*)preferredExternalAgent result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(NSString*)nonce {
     NSString *codeVerifier = [OIDAuthorizationRequest generateCodeVerifier];
     NSString *codeChallenge = [OIDAuthorizationRequest codeChallengeS256ForVerifier:codeVerifier];
 
@@ -21,7 +21,7 @@
                                       additionalParameters:additionalParameters];
     NSWindow *keyWindow = [[NSApplication sharedApplication] keyWindow];
     if(exchangeCode) {
-        NSObject<OIDExternalUserAgent> *agent = [self userAgentWithPresentingWindow:keyWindow useEphemeralSession:preferEphemeralSession];
+        NSObject<OIDExternalUserAgent> *agent = [self userAgentWithPresentingWindow:keyWindow preferredExternalAgent:preferredExternalAgent];
         return [OIDAuthState authStateByPresentingAuthorizationRequest:request externalUserAgent:agent callback:^(OIDAuthState *_Nullable authState,
                                                                                                                   NSError *_Nullable error) {
             if(authState) {
@@ -32,7 +32,7 @@
             }
         }];
     } else {
-        NSObject<OIDExternalUserAgent> *agent = [self userAgentWithPresentingWindow:keyWindow useEphemeralSession:preferEphemeralSession];
+        NSObject<OIDExternalUserAgent> *agent = [self userAgentWithPresentingWindow:keyWindow preferredExternalAgent:preferredExternalAgent];
         return [OIDAuthorizationService presentAuthorizationRequest:request externalUserAgent:agent callback:^(OIDAuthorizationResponse *_Nullable authorizationResponse, NSError *_Nullable error) {
             if(authorizationResponse) {
                 NSMutableDictionary *processedResponse = [[NSMutableDictionary alloc] init];
@@ -56,7 +56,7 @@
                                                                                                                                                                                                                                                  additionalParameters:requestParameters.additionalParameters];
     
     NSWindow *keyWindow = [[NSApplication sharedApplication] keyWindow];
-    id<OIDExternalUserAgent> externalUserAgent = [self userAgentWithPresentingWindow:keyWindow useEphemeralSession:requestParameters.preferEphemeralSession];
+    id<OIDExternalUserAgent> externalUserAgent = [self userAgentWithPresentingWindow:keyWindow preferredExternalAgent:requestParameters.preferredExternalAgent];
     return [OIDAuthorizationService presentEndSessionRequest:endSessionRequest externalUserAgent:externalUserAgent callback:^(OIDEndSessionResponse * _Nullable endSessionResponse, NSError * _Nullable error) {
         if(!endSessionResponse) {
             NSString *message = [NSString stringWithFormat:END_SESSION_ERROR_MESSAGE_FORMAT, [error localizedDescription]];
@@ -69,8 +69,8 @@
     }];
 }
 
-- (id<OIDExternalUserAgent>)userAgentWithPresentingWindow:(NSWindow *)presentingWindow useEphemeralSession:(BOOL)useEphemeralSession {
-    if (useEphemeralSession) {
+- (id<OIDExternalUserAgent>)userAgentWithPresentingWindow:(NSWindow *)presentingWindow preferredExternalAgent:(NSString*)preferredExternalAgent {
+    if ([preferredExternalAgent isEqual:@"ExternalAgentType.ephemeralAsWebAuthenticationSession"]) {
         return [[OIDExternalUserAgentMacNoSSO alloc] initWithPresentingWindow:presentingWindow];
     }
     return [[OIDExternalUserAgentMac alloc] initWithPresentingWindow:presentingWindow];

--- a/flutter_appauth_platform_interface/lib/flutter_appauth_platform_interface.dart
+++ b/flutter_appauth_platform_interface/lib/flutter_appauth_platform_interface.dart
@@ -6,6 +6,7 @@ export 'src/authorization_token_response.dart';
 export 'src/end_session_request.dart';
 export 'src/end_session_response.dart';
 export 'src/errors.dart';
+export 'src/external_agent_type.dart';
 export 'src/flutter_appauth_platform.dart';
 export 'src/grant_types.dart';
 export 'src/token_request.dart';

--- a/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
@@ -1,3 +1,5 @@
+import 'external_agent_type.dart';
+
 mixin AuthorizationParameters {
   /// Hint to the Authorization Server about the login identifier the End-User
   /// might use to log in.
@@ -7,11 +9,15 @@ mixin AuthorizationParameters {
   /// Server prompts the End-User for reauthentication and consent.
   List<String>? promptValues;
 
-  /// Whether to use an ephemeral session that prevents cookies and other
-  /// browser data being shared with the user's normal browser session.
-  ///
+  /// Decides what type of external agent to use for the authorization flow.
+  /// ASWebAuthenticationSession is the default for iOS 12 and above.
+  /// EphemeralSession is not sharing browser data
+  /// with the user's normal browser session but not keeping the cache
+  /// SFSafariViewController is not sharing browser data
+  /// with the user's normal browser session but keeping the cache.
   /// This property is only applicable to iOS versions 13 and above.
-  bool? preferEphemeralSession;
+  /// ExternalAgentType? preferredExternalAgent;
+  ExternalAgentType? preferredExternalAgent;
 
   String? responseMode;
 }

--- a/flutter_appauth_platform_interface/lib/src/authorization_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_request.dart
@@ -1,6 +1,7 @@
 import 'authorization_parameters.dart';
 import 'authorization_service_configuration.dart';
 import 'common_request_details.dart';
+import 'external_agent_type.dart';
 
 /// The details of an authorization request to get an authorization code.
 class AuthorizationRequest extends CommonRequestDetails
@@ -16,7 +17,8 @@ class AuthorizationRequest extends CommonRequestDetails
     Map<String, String>? additionalParameters,
     List<String>? promptValues,
     bool allowInsecureConnections = false,
-    bool preferEphemeralSession = false,
+    ExternalAgentType preferredExternalAgent =
+        ExternalAgentType.asWebAuthenticationSession,
     String? nonce,
     String? responseMode,
   }) {
@@ -30,7 +32,7 @@ class AuthorizationRequest extends CommonRequestDetails
     this.loginHint = loginHint;
     this.promptValues = promptValues;
     this.allowInsecureConnections = allowInsecureConnections;
-    this.preferEphemeralSession = preferEphemeralSession;
+    this.preferredExternalAgent = preferredExternalAgent;
     this.nonce = nonce;
     this.responseMode = responseMode;
     assertConfigurationInfo();

--- a/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
@@ -1,4 +1,5 @@
 import 'authorization_parameters.dart';
+import 'external_agent_type.dart';
 import 'grant_types.dart';
 import 'token_request.dart';
 
@@ -17,7 +18,8 @@ class AuthorizationTokenRequest extends TokenRequest
     super.discoveryUrl,
     List<String>? promptValues,
     super.allowInsecureConnections,
-    bool preferEphemeralSession = false,
+    ExternalAgentType preferredExternalAgent =
+        ExternalAgentType.asWebAuthenticationSession,
     super.nonce,
     String? responseMode,
   }) : super(
@@ -25,7 +27,7 @@ class AuthorizationTokenRequest extends TokenRequest
         ) {
     this.loginHint = loginHint;
     this.promptValues = promptValues;
-    this.preferEphemeralSession = preferEphemeralSession;
+    this.preferredExternalAgent = preferredExternalAgent;
     this.responseMode = responseMode;
   }
 }

--- a/flutter_appauth_platform_interface/lib/src/end_session_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/end_session_request.dart
@@ -8,7 +8,7 @@ class EndSessionRequest with AcceptedAuthorizationServiceConfigurationDetails {
     this.postLogoutRedirectUrl,
     this.state,
     this.allowInsecureConnections = false,
-    this.preferEphemeralSession = false,
+    this.preferredExternalAgent = ExternalAgentType.asWebAuthenticationSession,
     this.additionalParameters,
     String? issuer,
     String? discoveryUrl,
@@ -38,14 +38,17 @@ class EndSessionRequest with AcceptedAuthorizationServiceConfigurationDetails {
   /// This property is only applicable to Android.
   bool allowInsecureConnections;
 
-  /// Whether to use an ephemeral session that prevents cookies and other
-  /// browser data being shared with the user's normal browser session.
+  /// Decides what type of external agent to use for the authorization flow.
+  /// ASWebAuthenticationSession is the default for iOS 12 and above.
+  /// EphemeralSession is not sharing browser data
+  /// with the user's normal browser session but not keeping the cache
+  /// SFSafariViewController is not sharing browser data
+  /// with the user's normal browser session but keeping the cache.
+  /// This property is only applicable to iOS versions 13 and above.
+  /// ExternalAgentType? preferredExternalAgent;
   ///
-  /// This property is only applicable to iOS (versions 13 and above) and macOS.
-  ///
-  /// preferEphemeralSession = true must only be used here, if it is also used
-  /// for the sign in call.
-  bool preferEphemeralSession;
+  /// Sign in and out must have the same type.
+  ExternalAgentType? preferredExternalAgent;
 
   final Map<String, String>? additionalParameters;
 }

--- a/flutter_appauth_platform_interface/lib/src/external_agent_type.dart
+++ b/flutter_appauth_platform_interface/lib/src/external_agent_type.dart
@@ -1,0 +1,17 @@
+// Enum representing the type of external agent
+// to use for the authorization flow.
+enum ExternalAgentType {
+  /// Uses ASWebAuthenticationSession, the default for iOS 12 and above.
+  asWebAuthenticationSession,
+
+  /// Uses an ephemeral session that does not share browser data with
+  /// the user's normal browser session and does not keep the cache.
+  ephemeralAsWebAuthenticationSession,
+
+  /// Uses SFSafariViewController, which does not share browser data
+  /// with the user's normal browser session but keeps the cache.
+  ///
+  /// This is only applicable to iOS, on macOS it will use the same behavior as
+  /// ASWebAuthenticationSession.
+  sfSafariViewController
+}

--- a/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
@@ -33,7 +33,7 @@ extension EndSessionRequestMapper on EndSessionRequest {
       'issuer': issuer,
       'discoveryUrl': discoveryUrl,
       'serviceConfiguration': serviceConfiguration?.toMap(),
-      'preferEphemeralSession': preferEphemeralSession,
+      'preferredExternalAgent': preferredExternalAgent.toString(),
     };
   }
 }
@@ -99,7 +99,8 @@ Map<String, Object?> _convertAuthorizationParametersToMap(
   return <String, Object?>{
     'loginHint': authorizationParameters.loginHint,
     'promptValues': authorizationParameters.promptValues,
-    'preferEphemeralSession': authorizationParameters.preferEphemeralSession,
+    'preferredExternalAgent':
+        authorizationParameters.preferredExternalAgent.toString(),
     'responseMode': authorizationParameters.responseMode,
   };
 }

--- a/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
+++ b/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
@@ -38,7 +38,8 @@ void main() {
           'serviceConfiguration': null,
           'additionalParameters': null,
           'allowInsecureConnections': false,
-          'preferEphemeralSession': false,
+          'preferredExternalAgent':
+              ExternalAgentType.asWebAuthenticationSession.toString(),
           'promptValues': null,
           'responseMode': null,
           'nonce': null,
@@ -66,7 +67,8 @@ void main() {
           'serviceConfiguration': null,
           'additionalParameters': null,
           'allowInsecureConnections': false,
-          'preferEphemeralSession': false,
+          'preferredExternalAgent':
+              ExternalAgentType.asWebAuthenticationSession.toString(),
           'promptValues': null,
           'clientSecret': null,
           'refreshToken': null,
@@ -184,7 +186,8 @@ void main() {
         'issuer': null,
         'discoveryUrl': 'someDiscoveryUrl',
         'serviceConfiguration': null,
-        'preferEphemeralSession': false,
+        'preferredExternalAgent':
+            ExternalAgentType.asWebAuthenticationSession.toString(),
       })
     ]);
   });


### PR DESCRIPTION
**This fixes this issue:**
#538 

Implemented support for SFSafariController on iOS so that user can choose between `ASWebAuthenticationSession`, `EphemeralSession` and `SFSafariViewController`. 

**Reason**:
`ASWebAuthenticationSession` is having a displaying bug on iOS which would show "sign in" instead of "sign out" when user logs out.
![image](https://github.com/user-attachments/assets/0711cd84-4df7-4660-882d-246b18fc66de)
However, `EphemeralSession` is not fulfilling our requirement because it is using a private browser which doesn't save the cache. So user has to input the password every time when they login. `SFSafariViewController` would be the better choice between these three because it doesn't show the alert and keep the cache at the same time.

**Additional:**
To implement these changes, I had to modify the `flutter_appauth_platform_interface`. The changes are in the first commit. They would need to be published first on pub.dev. In the meantime, I access the change directly by referencing the path instead of the version.
<img width="517" alt="image" src="https://github.com/user-attachments/assets/fd464657-0e5d-4858-a686-bc28b907f758">
