### PR TITLE
Add try catch to uncaught exception

### DIFF
--- a/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
@@ -483,12 +483,15 @@ AppAuthAuthorization *authorization;
             openURL:(NSURL *)url
             options:
                 (NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
-  if ([_currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:url]) {
-    _currentAuthorizationFlow = nil;
-    return YES;
-  }
-
-  return NO;
+    @try {
+      if ([_currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:url]) {
+        _currentAuthorizationFlow = nil;
+        return YES;
+      }
+      return NO;
+    } @catch (NSException *exception) {
+        NSLog(@"Exception caught: %@, Reason: %@", exception.name, exception.reason);
+    }
 }
 
 - (BOOL)application:(UIApplication *)application

--- a/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
@@ -483,15 +483,16 @@ AppAuthAuthorization *authorization;
             openURL:(NSURL *)url
             options:
                 (NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options {
-    @try {
-      if ([_currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:url]) {
-        _currentAuthorizationFlow = nil;
-        return YES;
-      }
-      return NO;
-    } @catch (NSException *exception) {
-        NSLog(@"Exception caught: %@, Reason: %@", exception.name, exception.reason);
+  @try {
+    if ([_currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:url]) {
+      _currentAuthorizationFlow = nil;
+      return YES;
     }
+    return NO;
+  } @catch (NSException *exception) {
+    NSLog(@"Exception caught: %@, Reason: %@", exception.name,
+          exception.reason);
+  }
 }
 
 - (BOOL)application:(UIApplication *)application


### PR DESCRIPTION
As promised, I have created this pull request to address the bug where manually closing the login popup sheet could potentially trigger the following exception:
```
*** Terminating app due to uncaught exception 'An OAuth redirect was sent to a OIDExternalUserAgentSession after it already completed.', reason: 'An OAuth redirect was sent to a OIDExternalUserAgentSession after it already completed.'
*** First throw call stack:
(0x19f8a908c 0x19cbab2e4 0x19f9a4648 0x1027fe284 0x1037bf67c 0x10655f1a4 0x10652fe54 0x1031c95b0 0x1a3123f1c 0x1a312396c 0x1c2c5c248 0x1c2c2c68c 0x19f8460f4 0x19f845144 0x1038e671c 0x1038ea13c 0x1b8d5d3b8 0x1b8d5d338 0x1b8d5d210 0x19f87c088 0x19f87c01c 0x19f879b08 0x19f878d04 0x19f8785b8 0x1eb30e1c4 0x1a23ce2c0 0x1a247cddc 0x1a27a9b20 0x1032c47e8 0x1032c4760 0x1032c4864 0x1c504cd34)
libc++abi: terminating due to uncaught exception of type NSException
```