### PR TITLE
[flutter_appauth] added logic to recreate AuthorizationService objects if disposed but were needed

### DIFF
--- a/flutter_appauth/CHANGELOG.md
+++ b/flutter_appauth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [8.0.0-dev.4]
 
-* [Android] no functional changes but some code around dealing with `allowInsecureConnections` has been done in response to issue [554](https://github.com/MaikuB/flutter_appauth/issues/554)
+* [Android] some refactoring around code related to `allowInsecureConnections` has been done in response to issue [554](https://github.com/MaikuB/flutter_appauth/issues/554)
 * [Android] added logic to help with issues like [205](https://github.com/MaikuB/flutter_appauth/issues/205) where an app tries to refresh a token but the instances of `AuthorizationService` have been disposed
 
 ## [8.0.0-dev.3]

--- a/flutter_appauth/CHANGELOG.md
+++ b/flutter_appauth/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [8.0.0-dev.4]
 
 * [Android] no functional changes but some code around dealing with `allowInsecureConnections` has been done in response to issue [554](https://github.com/MaikuB/flutter_appauth/issues/554)
+* [Android] added logic to help with issues like [205](https://github.com/MaikuB/flutter_appauth/issues/205) where an app tries to refresh a token but the instances of `AuthorizationService` have been disposed
 
 ## [8.0.0-dev.3]
 

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -579,6 +579,10 @@ public class FlutterAppauthPlugin
   }
 
   private AuthorizationService getAuthorizationService() {
+    if (insecureAuthorizationService == null || defaultAuthorizationService == null) {
+      // There have been some reported instances where the services have been disposed but they're still needed e.g. to refresh token
+      createAuthorizationServices();
+    }
     AuthorizationService authorizationService =
         allowInsecureConnections ? insecureAuthorizationService : defaultAuthorizationService;
     return authorizationService;

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -580,7 +580,8 @@ public class FlutterAppauthPlugin
 
   private AuthorizationService getAuthorizationService() {
     if (insecureAuthorizationService == null || defaultAuthorizationService == null) {
-      // There have been some reported instances where the services have been disposed but they're still needed e.g. to refresh token
+      // There have been some reported instances where the services have been disposed but they're
+      // still needed e.g. to refresh token
       createAuthorizationServices();
     }
     AuthorizationService authorizationService =

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -143,7 +143,7 @@ public class FlutterAppauthPlugin
       authConfigBuilder.setConnectionBuilder(InsecureConnectionBuilder.INSTANCE);
       authConfigBuilder.setSkipIssuerHttpsCheck(true);
       insecureAuthorizationService =
-              new AuthorizationService(applicationContext, authConfigBuilder.build());
+          new AuthorizationService(applicationContext, authConfigBuilder.build());
     }
   }
 

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -134,12 +134,17 @@ public class FlutterAppauthPlugin
   }
 
   private void createAuthorizationServices() {
-    defaultAuthorizationService = new AuthorizationService(this.applicationContext);
-    AppAuthConfiguration.Builder authConfigBuilder = new AppAuthConfiguration.Builder();
-    authConfigBuilder.setConnectionBuilder(InsecureConnectionBuilder.INSTANCE);
-    authConfigBuilder.setSkipIssuerHttpsCheck(true);
-    insecureAuthorizationService =
-        new AuthorizationService(applicationContext, authConfigBuilder.build());
+    if (defaultAuthorizationService == null) {
+      defaultAuthorizationService = new AuthorizationService(this.applicationContext);
+    }
+
+    if (insecureAuthorizationService == null) {
+      AppAuthConfiguration.Builder authConfigBuilder = new AppAuthConfiguration.Builder();
+      authConfigBuilder.setConnectionBuilder(InsecureConnectionBuilder.INSTANCE);
+      authConfigBuilder.setSkipIssuerHttpsCheck(true);
+      insecureAuthorizationService =
+              new AuthorizationService(applicationContext, authConfigBuilder.build());
+    }
   }
 
   private void disposeAuthorizationServices() {
@@ -579,11 +584,9 @@ public class FlutterAppauthPlugin
   }
 
   private AuthorizationService getAuthorizationService() {
-    if (insecureAuthorizationService == null || defaultAuthorizationService == null) {
-      // There have been some reported instances where the services have been disposed but they're
-      // still needed e.g. to refresh token
-      createAuthorizationServices();
-    }
+    // Call to  createAuthorizationService()is done as there have been some reported instances where
+    // the services have been disposed but they're still needed e.g. to refresh tokens
+    createAuthorizationServices();
     AuthorizationService authorizationService =
         allowInsecureConnections ? insecureAuthorizationService : defaultAuthorizationService;
     return authorizationService;

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -584,7 +584,7 @@ public class FlutterAppauthPlugin
   }
 
   private AuthorizationService getAuthorizationService() {
-    // Call to  createAuthorizationService()is done as there have been some reported instances where
+    // Call to createAuthorizationService() is done as there have been some reported instances where
     // the services have been disposed but they're still needed e.g. to refresh tokens
     createAuthorizationServices();
     AuthorizationService authorizationService =


### PR DESCRIPTION
Relates to #205 