### PR TITLE
[flutter_appauth] Fix exception: login hint must not empty if hint empty in android

### DIFF
--- a/flutter_appauth_platform_interface/lib/src/authorization_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_request.dart
@@ -4,8 +4,7 @@ import 'common_request_details.dart';
 import 'external_user_agent.dart';
 
 /// The details of an authorization request to get an authorization code.
-class AuthorizationRequest extends CommonRequestDetails
-    with AuthorizationParameters {
+class AuthorizationRequest extends CommonRequestDetails with AuthorizationParameters {
   AuthorizationRequest(
     String clientId,
     String redirectUrl, {
@@ -17,8 +16,7 @@ class AuthorizationRequest extends CommonRequestDetails
     Map<String, String>? additionalParameters,
     List<String>? promptValues,
     bool allowInsecureConnections = false,
-    ExternalUserAgent externalUserAgent =
-        ExternalUserAgent.asWebAuthenticationSession,
+    ExternalUserAgent externalUserAgent = ExternalUserAgent.asWebAuthenticationSession,
     String? nonce,
     String? responseMode,
   }) {
@@ -29,7 +27,12 @@ class AuthorizationRequest extends CommonRequestDetails
     this.additionalParameters = additionalParameters;
     this.issuer = issuer;
     this.discoveryUrl = discoveryUrl;
-    this.loginHint = loginHint;
+    if (loginHint?.isEmpty == true) {
+      this.loginHint = null;
+    } else {
+      this.loginHint = loginHint;
+    }
+
     this.promptValues = promptValues;
     this.allowInsecureConnections = allowInsecureConnections;
     this.externalUserAgent = externalUserAgent;


### PR DESCRIPTION
As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_appauth])