### PR TITLE
[flutter_appauth] remove idTokenHint assert

### DIFF
--- a/flutter_appauth_platform_interface/lib/src/end_session_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/end_session_request.dart
@@ -13,8 +13,7 @@ class EndSessionRequest with AcceptedAuthorizationServiceConfigurationDetails {
     String? issuer,
     String? discoveryUrl,
     AuthorizationServiceConfiguration? serviceConfiguration,
-  }) : assert((idTokenHint == null && postLogoutRedirectUrl == null) ||
-            (idTokenHint != null && postLogoutRedirectUrl != null)) {
+  }) {
     this.serviceConfiguration = serviceConfiguration;
     this.issuer = issuer;
     this.discoveryUrl = discoveryUrl;


### PR DESCRIPTION
Hi @MaikuB 

I am wondering if there is a specific reason for this assert?

Currently we want to only supply our postLogoutRedirectUrl but not the idTokenHint for logging out in our app. We tried using the additionalParameters field to supply only the post_logout_redirect_uri, but that causes fatal exception in android.

Would be nice to remove this assert, unless there is a reason with OpenID why we'd want to enforce it like this.

Let me know!
Thank you!