### PR TITLE
[flutter_appauth] iOS app would crash when `authorizationCode` was `nil`

### DIFF
--- a/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.m
+++ b/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.m
@@ -75,37 +75,53 @@
                            callback:^(OIDAuthorizationResponse
                                           *_Nullable authorizationResponse,
                                       NSError *_Nullable error) {
-                             if (authorizationResponse) {
-                               NSMutableDictionary *processedResponse =
-                                   [[NSMutableDictionary alloc] init];
-                               [processedResponse
-                                   setObject:authorizationResponse
-                                                 .additionalParameters
-                                      forKey:
-                                          @"authorizationAdditionalParameters"];
-                               [processedResponse
-                                   setObject:authorizationResponse
-                                                 .authorizationCode
-                                      forKey:@"authorizationCode"];
-                               [processedResponse
-                                   setObject:authorizationResponse.request
-                                                 .codeVerifier
-                                      forKey:@"codeVerifier"];
-                               [processedResponse
-                                   setObject:authorizationResponse.request.nonce
-                                      forKey:@"nonce"];
-                               result(processedResponse);
-                             } else {
-                               [FlutterAppAuth
-                                   finishWithError:AUTHORIZE_ERROR_CODE
-                                           message:
-                                               [FlutterAppAuth
-                                                   formatMessageWithError:
-                                                       AUTHORIZE_ERROR_MESSAGE_FORMAT
-                                                                    error:error]
-                                            result:result
-                                             error:error];
-                             }
+                                        @try {
+                                            if (authorizationResponse) {
+                                            NSMutableDictionary *processedResponse =
+                                                [[NSMutableDictionary alloc] init];
+                                            [processedResponse
+                                                setObject:authorizationResponse
+                                                                .additionalParameters
+                                                   forKey:
+                                                        @"authorizationAdditionalParameters"];
+                                            [processedResponse
+                                                setObject:authorizationResponse
+                                                                .authorizationCode
+                                                    forKey:@"authorizationCode"];
+                                            [processedResponse
+                                                setObject:authorizationResponse.request
+                                                                .codeVerifier
+                                                    forKey:@"codeVerifier"];
+                                            [processedResponse
+                                                setObject:authorizationResponse.request.nonce
+                                                    forKey:@"nonce"];
+                                            result(processedResponse);
+                                            } else {
+                                                [FlutterAppAuth
+                                                    finishWithError:AUTHORIZE_ERROR_CODE
+                                                            message:
+                                                                [FlutterAppAuth
+                                                                    formatMessageWithError:
+                                                                        AUTHORIZE_ERROR_MESSAGE_FORMAT
+                                                                                    error:error]
+                                                            result:result
+                                                                error:error];
+                                            }
+                                        } @catch (NSException *e) {
+                                            error = [NSError errorWithDomain:e.name code:0 userInfo:@{
+                                                NSUnderlyingErrorKey: e,
+                                                NSDebugDescriptionErrorKey: e.userInfo ?: @{ },
+                                                NSLocalizedFailureReasonErrorKey: (e.reason ?: @"Failed to set processedResponse") }];
+                                            [FlutterAppAuth
+                                                finishWithError:AUTHORIZE_ERROR_CODE
+                                                        message:
+                                                            [FlutterAppAuth
+                                                                formatMessageWithError:
+                                                                    AUTHORIZE_ERROR_MESSAGE_FORMAT
+                                                                                error:error]
+                                                        result:result
+                                                        error:error];
+                                        }
                            }];
   }
 }

--- a/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.m
+++ b/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.m
@@ -75,53 +75,53 @@
                            callback:^(OIDAuthorizationResponse
                                           *_Nullable authorizationResponse,
                                       NSError *_Nullable error) {
-                                        @try {
-                                            if (authorizationResponse) {
-                                            NSMutableDictionary *processedResponse =
-                                                [[NSMutableDictionary alloc] init];
-                                            [processedResponse
-                                                setObject:authorizationResponse
-                                                                .additionalParameters
-                                                   forKey:
-                                                        @"authorizationAdditionalParameters"];
-                                            [processedResponse
-                                                setObject:authorizationResponse
-                                                                .authorizationCode
-                                                    forKey:@"authorizationCode"];
-                                            [processedResponse
-                                                setObject:authorizationResponse.request
-                                                                .codeVerifier
-                                                    forKey:@"codeVerifier"];
-                                            [processedResponse
-                                                setObject:authorizationResponse.request.nonce
-                                                    forKey:@"nonce"];
-                                            result(processedResponse);
-                                            } else {
+                            @try {
+                                if (authorizationResponse) {
+                                NSMutableDictionary *processedResponse =
+                                    [[NSMutableDictionary alloc] init];
+                                [processedResponse
+                                    setObject:authorizationResponse
+                                                    .additionalParameters
+                                        forKey:
+                                            @"authorizationAdditionalParameters"];
+                                [processedResponse
+                                    setObject:authorizationResponse
+                                                    .authorizationCode
+                                        forKey:@"authorizationCode"];
+                                [processedResponse
+                                    setObject:authorizationResponse.request
+                                                    .codeVerifier
+                                        forKey:@"codeVerifier"];
+                                [processedResponse
+                                    setObject:authorizationResponse.request.nonce
+                                        forKey:@"nonce"];
+                                result(processedResponse);
+                                } else {
+                                    [FlutterAppAuth
+                                        finishWithError:AUTHORIZE_ERROR_CODE
+                                                message:
+                                                    [FlutterAppAuth
+                                                        formatMessageWithError:
+                                                            AUTHORIZE_ERROR_MESSAGE_FORMAT
+                                                                        error:error]
+                                                result:result
+                                                    error:error];
+                                }
+                            } @catch (NSException *e) {
+                                error = [NSError errorWithDomain:e.name code:0 userInfo:@{
+                                    NSUnderlyingErrorKey: e,
+                                    NSDebugDescriptionErrorKey: e.userInfo ?: @{ },
+                                    NSLocalizedFailureReasonErrorKey: (e.reason ?: @"Failed to set processedResponse") }];
+                                [FlutterAppAuth
+                                    finishWithError:AUTHORIZE_ERROR_CODE
+                                            message:
                                                 [FlutterAppAuth
-                                                    finishWithError:AUTHORIZE_ERROR_CODE
-                                                            message:
-                                                                [FlutterAppAuth
-                                                                    formatMessageWithError:
-                                                                        AUTHORIZE_ERROR_MESSAGE_FORMAT
-                                                                                    error:error]
-                                                            result:result
-                                                                error:error];
-                                            }
-                                        } @catch (NSException *e) {
-                                            error = [NSError errorWithDomain:e.name code:0 userInfo:@{
-                                                NSUnderlyingErrorKey: e,
-                                                NSDebugDescriptionErrorKey: e.userInfo ?: @{ },
-                                                NSLocalizedFailureReasonErrorKey: (e.reason ?: @"Failed to set processedResponse") }];
-                                            [FlutterAppAuth
-                                                finishWithError:AUTHORIZE_ERROR_CODE
-                                                        message:
-                                                            [FlutterAppAuth
-                                                                formatMessageWithError:
-                                                                    AUTHORIZE_ERROR_MESSAGE_FORMAT
-                                                                                error:error]
-                                                        result:result
-                                                        error:error];
-                                        }
+                                                    formatMessageWithError:
+                                                        AUTHORIZE_ERROR_MESSAGE_FORMAT
+                                                                    error:error]
+                                            result:result
+                                            error:error];
+                            }
                            }];
   }
 }


### PR DESCRIPTION
Wrapping the offending code in a try/catch and sending it up to the dart code.