### PR TITLE
[flutter_appauth] fix typo in README.md

### DIFF
--- a/flutter_appauth/README.md
+++ b/flutter_appauth/README.md
@@ -113,7 +113,7 @@ If your server has an [end session endpoint](https://openid.net/specs/openid-con
 await appAuth.endSession(EndSessionRequest(
           idTokenHint: '<idToken>',
           postLogoutRedirectUrl: '<postLogoutRedirectUrl>',
-          serviceConfiguration: AuthorizationServiceConfiguration(authorizationEndpoint: '<authorization_endpoint>',  tokenEndpooint: '<token_endpoint>', endSessionEndpoint: '<end_session_endpoint>'));
+          serviceConfiguration: AuthorizationServiceConfiguration(authorizationEndpoint: '<authorization_endpoint>',  tokenEndpoint: '<token_endpoint>', endSessionEndpoint: '<end_session_endpoint>'));
 ```
 
 The above code passes an `AuthorizationServiceConfiguration` with all the endpoints defined but alternatives are to specify an `issuer` or `discoveryUrl` like you would with the other APIs in the plugin (e.g. `authorizeAndExchangeCode()`).

--- a/flutter_appauth/README.md
+++ b/flutter_appauth/README.md
@@ -113,7 +113,7 @@ If your server has an [end session endpoint](https://openid.net/specs/openid-con
 await appAuth.endSession(EndSessionRequest(
           idTokenHint: '<idToken>',
           postLogoutRedirectUrl: '<postLogoutRedirectUrl>',
-          serviceConfiguration: AuthorizationServiceConfiguration(authorizationEndpoint: '<authorization_endpoint>',  tokenEndpoint: '<token_endpoint>', endSessionEndpoint: '<end_session_endpoint>')));
+          serviceConfiguration: AuthorizationServiceConfiguration(authorizationEndpoint: '<authorization_endpoint>', tokenEndpoint: '<token_endpoint>', endSessionEndpoint: '<end_session_endpoint>')));
 ```
 
 The above code passes an `AuthorizationServiceConfiguration` with all the endpoints defined but alternatives are to specify an `issuer` or `discoveryUrl` like you would with the other APIs in the plugin (e.g. `authorizeAndExchangeCode()`).

--- a/flutter_appauth/README.md
+++ b/flutter_appauth/README.md
@@ -113,7 +113,7 @@ If your server has an [end session endpoint](https://openid.net/specs/openid-con
 await appAuth.endSession(EndSessionRequest(
           idTokenHint: '<idToken>',
           postLogoutRedirectUrl: '<postLogoutRedirectUrl>',
-          serviceConfiguration: AuthorizationServiceConfiguration(authorizationEndpoint: '<authorization_endpoint>',  tokenEndpoint: '<token_endpoint>', endSessionEndpoint: '<end_session_endpoint>'));
+          serviceConfiguration: AuthorizationServiceConfiguration(authorizationEndpoint: '<authorization_endpoint>',  tokenEndpoint: '<token_endpoint>', endSessionEndpoint: '<end_session_endpoint>')));
 ```
 
 The above code passes an `AuthorizationServiceConfiguration` with all the endpoints defined but alternatives are to specify an `issuer` or `discoveryUrl` like you would with the other APIs in the plugin (e.g. `authorizeAndExchangeCode()`).


### PR DESCRIPTION
fix typo

As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_appauth])