### PR TITLE
[various] updates to migrate example app to use plugin DSL

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build
         run: melos run build:example_android
   build_example_android_3_13:
-      name: Build Android example app (3.13)
+      name: Build Android example app (3.19)
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
         - uses: subosito/flutter-action@v2
           with:
             channel: stable
-            flutter-version: 3.13.0
+            flutter-version: 3.19.0
             cache: true
             cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
         - name: Install Tools
@@ -85,14 +85,14 @@ jobs:
       - name: Build
         run: melos run build:example_ios
   build_example_ios_3_13:
-    name: Build iOS example app (3.13)
+    name: Build iOS example app (3.19)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: 3.13.0
+          flutter-version: 3.19.0
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
       - name: Install Tools
@@ -114,14 +114,14 @@ jobs:
       - name: Build
         run: melos run build:example_macos
   build_example_macos_3_13:
-    name: Build macOS example app (3.13)
+    name: Build macOS example app (3.19)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-          flutter-version: 3.13.0
+          flutter-version: 3.19.0
           cache: true
           cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
       - name: Install Tools

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,7 +51,7 @@ jobs:
         run: ./.github/workflows/scripts/install-tools.sh
       - name: Build
         run: melos run build:example_android
-  build_example_android_3_13:
+  build_example_android_3_19:
       name: Build Android example app (3.19)
       runs-on: ubuntu-latest
       steps:
@@ -84,7 +84,7 @@ jobs:
         run: ./.github/workflows/scripts/install-tools.sh
       - name: Build
         run: melos run build:example_ios
-  build_example_ios_3_13:
+  build_example_ios_3_19:
     name: Build iOS example app (3.19)
     runs-on: macos-latest
     steps:
@@ -113,7 +113,7 @@ jobs:
         run: ./.github/workflows/scripts/install-tools.sh
       - name: Build
         run: melos run build:example_macos
-  build_example_macos_3_13:
+  build_example_macos_3_19:
     name: Build macOS example app (3.19)
     runs-on: macos-latest
     steps:

--- a/flutter_appauth/CHANGELOG.md
+++ b/flutter_appauth/CHANGELOG.md
@@ -3,6 +3,7 @@
 * **Breaking change** Updated minimum supported SDK version to Flutter 3.16/Dart 3.2
 * [iOS][macOS] added Swift Package Manager support
 * [iOS][macOS] **Breaking changes** a number of Objective-C headers that were public are now no longer public. This means that classes were defined on the native side of the plugin may now no longer visible. These changes likely don't affect users of the plugin as this is to do with APIs that can be accessed via Objective-C or Swift. These changes were done to add Swift Package Manager support
+* Bumped `flutter_lints` dev dependency
 
 ## [8.0.2]
 

--- a/flutter_appauth/CHANGELOG.md
+++ b/flutter_appauth/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [9.0.0-dev.1]
 
 * **Breaking change** updated minimum supported SDK version to Flutter 3.19/Dart 3.3
+* [Android] **Breaking changes** updated `compileSdkVersion` to 33 and AGP to 8.0.1 to align with what's used by the AppAuth Android SDK
 * [iOS][macOS] added Swift Package Manager support
 * [iOS][macOS] **Breaking changes** a number of Objective-C headers that were public are now no longer public. This means that classes were defined on the native side of the plugin may now no longer visible. These changes likely don't affect users of the plugin as this is to do with APIs that can be accessed via Objective-C or Swift. These changes were done to add Swift Package Manager support
 * Migrated Android side of example to use plugin DSL

--- a/flutter_appauth/CHANGELOG.md
+++ b/flutter_appauth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [9.0.0-dev.1]
 
-* **Breaking change** Updated minimum supported SDK version to Flutter 3.16/Dart 3.2
+* **Breaking change** updated minimum supported SDK version to Flutter 3.19/Dart 3.3
 * [iOS][macOS] added Swift Package Manager support
 * [iOS][macOS] **Breaking changes** a number of Objective-C headers that were public are now no longer public. This means that classes were defined on the native side of the plugin may now no longer visible. These changes likely don't affect users of the plugin as this is to do with APIs that can be accessed via Objective-C or Swift. These changes were done to add Swift Package Manager support
 * Migrated Android side of example to use plugin DSL

--- a/flutter_appauth/CHANGELOG.md
+++ b/flutter_appauth/CHANGELOG.md
@@ -3,6 +3,7 @@
 * **Breaking change** Updated minimum supported SDK version to Flutter 3.16/Dart 3.2
 * [iOS][macOS] added Swift Package Manager support
 * [iOS][macOS] **Breaking changes** a number of Objective-C headers that were public are now no longer public. This means that classes were defined on the native side of the plugin may now no longer visible. These changes likely don't affect users of the plugin as this is to do with APIs that can be accessed via Objective-C or Swift. These changes were done to add Swift Package Manager support
+* Migrated Android side of example to use plugin DSL
 * Bumped `flutter_lints` dev dependency
 
 ## [8.0.2]

--- a/flutter_appauth/CHANGELOG.md
+++ b/flutter_appauth/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [9.0.0-dev.1]
 
+* **Breaking change** Updated minimum supported SDK version to Flutter 3.16/Dart 3.2
 * [iOS][macOS] added Swift Package Manager support
 * [iOS][macOS] **Breaking changes** a number of Objective-C headers that were public are now no longer public. This means that classes were defined on the native side of the plugin may now no longer visible. These changes likely don't affect users of the plugin as this is to do with APIs that can be accessed via Objective-C or Swift. These changes were done to add Swift Package Manager support
 

--- a/flutter_appauth/android/build.gradle
+++ b/flutter_appauth/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.0.1'
     }
 }
 
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     if (project.android.hasProperty("namespace")) {
         namespace 'io.crossingthestreams.flutterappauth'

--- a/flutter_appauth/example/android/app/build.gradle
+++ b/flutter_appauth/example/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "io.crossingthestreams.flutter_appauth_example"
-    compileSdkVersion 34
+    compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -66,5 +66,3 @@ android {
 flutter {
     source '../..'
 }
-
-dependencies {}

--- a/flutter_appauth/example/android/build.gradle
+++ b/flutter_appauth/example/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.7.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/flutter_appauth/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_appauth/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/flutter_appauth/example/android/settings.gradle
+++ b/flutter_appauth/example/android/settings.gradle
@@ -5,16 +5,21 @@ pluginManagement {
         def flutterSdkPath = properties.getProperty("flutter.sdk")
         assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
         return flutterSdkPath
-    }
-    settings.ext.flutterSdkPath = flutterSdkPath()
+    }()
 
-    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-    plugins {
-        id "dev.flutter.flutter-gradle-plugin" version "1.0.0" apply false
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
     }
 }
 
-include ":app"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.6.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+}
 
-apply from: "${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+include ":app"

--- a/flutter_appauth/example/pubspec.yaml
+++ b/flutter_appauth/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   http: ^1.0.0
 
 dev_dependencies:
-  flutter_lints: ^3.0.2
+  flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
   integration_test:

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -6,13 +6,13 @@ version: 9.0.0-dev.1
 homepage: https://github.com/MaikuB/flutter_appauth/tree/master/flutter_appauth
 
 environment:
-  sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  sdk: ^3.2.0
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_appauth_platform_interface: ^8.0.0
+  flutter_appauth_platform_interface: ^9.0.0
 
 flutter:
   plugin:

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -25,4 +25,4 @@ flutter:
       macos:
         pluginClass: FlutterAppauthPlugin
 dev_dependencies:
-  flutter_lints: ^3.0.2
+  flutter_lints: ^4.0.0

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -6,8 +6,8 @@ version: 9.0.0-dev.1
 homepage: https://github.com/MaikuB/flutter_appauth/tree/master/flutter_appauth
 
 environment:
-  sdk: ^3.2.0
-  flutter: ">=3.16.0"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/flutter_appauth_platform_interface/CHANGELOG.md
+++ b/flutter_appauth_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [9.0.0]
 
-* **Breaking change** Updated minimum supported SDK version to Flutter 3.16/Dart 3.2
+* **Breaking change** updated minimum supported SDK version to Flutter 3.19/Dart 3.3
 * Bumped `flutter_lints` dev dependency
 
 ## [8.0.0]

--- a/flutter_appauth_platform_interface/CHANGELOG.md
+++ b/flutter_appauth_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [9.0.0]
 
 * **Breaking change** Updated minimum supported SDK version to Flutter 3.16/Dart 3.2
+* Bumped `flutter_lints` dev dependency
 
 ## [8.0.0]
 

--- a/flutter_appauth_platform_interface/CHANGELOG.md
+++ b/flutter_appauth_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [9.0.0]
+
+* **Breaking change** Updated minimum supported SDK version to Flutter 3.16/Dart 3.2
+
 ## [8.0.0]
 
 * **Breaking change** Replaced the `preferEphemeralSession` property in the `AuthorizationRequest`, `AuthorizationTokenRequest` and  `EndSessionRequest` classes with `externalUserAgent`. Thanks to the PR from [john-slow](https://github.com/john-slow). `externalUserAgent` is presented by the newly `ExternalUserAgent` enum that has the following values

--- a/flutter_appauth_platform_interface/CHANGELOG.md
+++ b/flutter_appauth_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [9.0.0]
+## [9.0.0-dev.1]
 
 * **Breaking change** updated minimum supported SDK version to Flutter 3.19/Dart 3.3
 * Bumped `flutter_lints` dev dependency

--- a/flutter_appauth_platform_interface/pubspec.yaml
+++ b/flutter_appauth_platform_interface/pubspec.yaml
@@ -1,11 +1,11 @@
 name: flutter_appauth_platform_interface
 description: A common platform interface for the flutter_appauth plugin.
-version: 8.0.0
+version: 9.0.0
 homepage: https://github.com/MaikuB/flutter_appauth/tree/master/flutter_appauth_platform_interface
 
 environment:
-  sdk: ^3.1.0
-  flutter: ">=3.13.0"
+  sdk: ^3.2.0
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:

--- a/flutter_appauth_platform_interface/pubspec.yaml
+++ b/flutter_appauth_platform_interface/pubspec.yaml
@@ -13,6 +13,6 @@ dependencies:
   plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
-  flutter_lints: ^3.0.2
+  flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter

--- a/flutter_appauth_platform_interface/pubspec.yaml
+++ b/flutter_appauth_platform_interface/pubspec.yaml
@@ -4,8 +4,8 @@ version: 9.0.0
 homepage: https://github.com/MaikuB/flutter_appauth/tree/master/flutter_appauth_platform_interface
 
 environment:
-  sdk: ^3.2.0
-  flutter: ">=3.16.0"
+  sdk: ^3.3.0
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/flutter_appauth_platform_interface/pubspec.yaml
+++ b/flutter_appauth_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_appauth_platform_interface
 description: A common platform interface for the flutter_appauth plugin.
-version: 9.0.0
+version: 9.0.0-dev.1
 homepage: https://github.com/MaikuB/flutter_appauth/tree/master/flutter_appauth_platform_interface
 
 environment:


### PR DESCRIPTION
Migrated example app to use plugin DSL. Plugin and platform interface has minimum SDK versions bumped to Flutter 3.19/Dart 3.3 accordingly as aligns with when they're recommended versions as described in the [Flutter docs](https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply)

As part of this the Android side of the plugin has the `compileSdkVersion` bumped to 33 and AGP to 8.0.1 to align with what's used to build the AppAuth Android SDK itself.

The AGP version of the example app is also bumped to 8.6.0 to align with the [minimum tooling versions](https://developer.android.com/build/releases/gradle-plugin#api-level-support) to allow the example to compile and target using API 35