### PR TITLE
Deley to create AuthorizationService in Android

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -147,10 +147,14 @@ public class FlutterAppauthPlugin
   }
 
   private void disposeAuthorizationServices() {
-    defaultAuthorizationService.dispose();
-    insecureAuthorizationService.dispose();
-    defaultAuthorizationService = null;
-    insecureAuthorizationService = null;
+      if (defaultAuthorizationService != null) {
+          defaultAuthorizationService.dispose();
+          defaultAuthorizationService = null;
+      }
+      if (insecureAuthorizationService != null) {
+        insecureAuthorizationService.dispose();
+        insecureAuthorizationService = null;
+      }
   }
 
   private void checkAndSetPendingOperation(String method, Result result) {


### PR DESCRIPTION
Avoid the plugin from reading the application list as soon as it is loaded. In some scenarios, we need the user to agree to the privacy agreement before reading the user's application list.