### PR TITLE
implement support for external custom browsers

### DIFF
--- a/flutter_appauth/example/lib/main.dart
+++ b/flutter_appauth/example/lib/main.dart
@@ -126,6 +126,19 @@ class _MyAppState extends State<MyApp> {
                               ExternalUserAgent.sfSafariViewController),
                     ),
                   ),
+                if (Platform.isIOS)
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: ElevatedButton(
+                      child: const Text(
+                        'Auto code exchange using system browser (iOS only)',
+                        textAlign: TextAlign.center,
+                      ),
+                      onPressed: () => _signInWithAutoCodeExchange(
+                        externalUserAgent:
+                          ExternalUserAgent.customBrowser),
+                    ),
+                  ),
                 ElevatedButton(
                   onPressed: _refreshToken != null ? _refresh : null,
                   child: const Text('Refresh token'),

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/AppAuthIOSAuthorization.m
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/AppAuthIOSAuthorization.m
@@ -173,6 +173,9 @@
     return [[OIDExternalUserAgentIOSSafariViewController alloc]
         initWithPresentingViewController:rootViewController];
   }
+  if ([externalUserAgent integerValue] == CustomBrowser) {
+    return [OIDExternalUserAgentIOSCustomBrowser CustomBrowserSafari];
+  }
   return [[OIDExternalUserAgentIOS alloc]
       initWithPresentingViewController:rootViewController];
 }

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.h
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.h
@@ -61,7 +61,8 @@ static NSString *const END_SESSION_ERROR_MESSAGE_FORMAT =
 typedef NS_ENUM(NSInteger, ExternalUserAgent) {
   ASWebAuthenticationSession,
   EphemeralASWebAuthenticationSession,
-  SafariViewController
+  SafariViewController,
+  CustomBrowser
 };
 
 @interface AppAuthAuthorization : NSObject

--- a/flutter_appauth_platform_interface/lib/src/external_user_agent.dart
+++ b/flutter_appauth_platform_interface/lib/src/external_user_agent.dart
@@ -45,5 +45,12 @@ enum ExternalUserAgent {
   /// Note that as this does not follow the best practices on using the
   /// appropriate native APIs based on the OS version, developers should use
   /// this at their own discretion.
-  sfSafariViewController
+  sfSafariViewController,
+
+
+  /// Indicates a preference for using an external user-agent,
+  /// suitable for e.g. the secure browser of a MDM solution,
+  /// SSO flows and using the cookies/context of the system main browser.
+  /// This is only applicable to iOS (fallback is [asWebAuthenticationSession]).
+  customBrowser
 }


### PR DESCRIPTION
Adds support for external (non-in-app) browsers on iOS to participate in SSO-sessions and allow e.g. Citrix MDM to provide its secure browser (which in turn allows SSO for e.g. enterprise Kerberos environments).

Fixes #565 but probably raises the same questions that were left unanswered in https://github.com/MaikuB/flutter_appauth/pull/318
Given that this unblocks some users, it might still be valuable.