### PR TITLE
Update README - Android setup

### DIFF
--- a/flutter_appauth/README.md
+++ b/flutter_appauth/README.md
@@ -167,10 +167,28 @@ Otherwise, there will be still an active login session in the browser.
 
 ## Android setup
 
-Go to the `build.gradle` file for your Android app to specify the custom scheme so that there should be a section in it that look similar to the following but replace `<your_custom_scheme>` with the desired value
+Go to the `build.gradle.kts` file for your Android app to specify the custom scheme so that there should be a section in it that look similar to the following but replace `<your_custom_scheme>` with the desired value:
 
+```kotlin
+
+android {
+    ...
+    defaultConfig {
+        ...
+        manifestPlaceholders.putAll(
+            mapOf(
+                "appAuthRedirectScheme" to "<your_custom_scheme>"
+            )
+        )
+    }
+}
 ```
-...groovy
+
+If you're using `build.gradle`:
+
+
+```groovy
+
 android {
     ...
     defaultConfig {


### PR DESCRIPTION
New Flutter projects use the Kotlin DSL for Gradle files by default (since 3.29). I've updated the README to reflect these changes.