### PR TITLE
[flutter_appauth] fixed crash if main activity has been destroyed/unbound

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -60,6 +60,7 @@ public class FlutterAppauthPlugin
   private static final String TOKEN_ERROR_CODE = "token_failed";
   private static final String END_SESSION_ERROR_CODE = "end_session_failed";
   private static final String NULL_INTENT_ERROR_CODE = "null_intent";
+  private static final String NULL_ACTIVITY_ERROR_CODE = "null_activity";
   private static final String INVALID_CLAIMS_ERROR_CODE = "invalid_claims";
   private static final String NO_BROWSER_AVAILABLE_ERROR_CODE = "no_browser_available";
 
@@ -74,6 +75,9 @@ public class FlutterAppauthPlugin
 
   private static final String NULL_INTENT_ERROR_FORMAT =
       "Failed to authorize: Null intent received";
+
+  private static final String NULL_ACTIVITY_ERROR_FORMAT =
+      "Failed to authorize: Null activity received";
   private static final String NO_BROWSER_AVAILABLE_ERROR_FORMAT =
       "Failed to authorize: No suitable browser is available";
 
@@ -466,6 +470,8 @@ public class FlutterAppauthPlugin
           authIntent, exchangeCode ? RC_AUTH_EXCHANGE_CODE : RC_AUTH);
     } catch (ActivityNotFoundException ex) {
       finishWithError(NO_BROWSER_AVAILABLE_ERROR_CODE, NO_BROWSER_AVAILABLE_ERROR_FORMAT, ex);
+    } catch (NullPointerException ex) {
+      finishWithError(NULL_ACTIVITY_ERROR_CODE, NULL_ACTIVITY_ERROR_FORMAT, ex);
     }
   }
 
@@ -576,7 +582,12 @@ public class FlutterAppauthPlugin
     final EndSessionRequest endSessionRequest = endSessionRequestBuilder.build();
     AuthorizationService authorizationService = getAuthorizationService();
     Intent endSessionIntent = authorizationService.getEndSessionRequestIntent(endSessionRequest);
-    mainActivity.startActivityForResult(endSessionIntent, RC_END_SESSION);
+
+    try {
+      mainActivity.startActivityForResult(endSessionIntent, RC_END_SESSION);
+    } catch (NullPointerException ex) {
+      finishWithError(NULL_ACTIVITY_ERROR_CODE, NULL_ACTIVITY_ERROR_FORMAT, ex);
+    }
   }
 
   private AuthorizationService getAuthorizationService() {


### PR DESCRIPTION
# Context

We've seen a couple of instances in our crashlytics logs of a crash happening due to the activity object being null when `startActivityForResult` is called.

### Crash log

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.app.Activity.startActivityForResult(android.content.Intent, int)' on a null object reference
       at io.crossingthestreams.flutterappauth.FlutterAppauthPlugin.performAuthorization(FlutterAppauthPlugin.java:465)
       at io.crossingthestreams.flutterappauth.FlutterAppauthPlugin.access$300(FlutterAppauthPlugin.java)
       at io.crossingthestreams.flutterappauth.FlutterAppauthPlugin$1.onFetchConfigurationCompleted(FlutterAppauthPlugin.java:331)
       at net.openid.appauth.AuthorizationServiceConfiguration$ConfigurationRetrievalAsyncTask.onPostExecute(AuthorizationServiceConfiguration.java:417)
       at net.openid.appauth.AuthorizationServiceConfiguration$ConfigurationRetrievalAsyncTask.onPostExecute(AuthorizationServiceConfiguration.java:358)
       at android.os.AsyncTask.finish(AsyncTask.java:771)
       at android.os.AsyncTask.access$900(AsyncTask.java:199)
       at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:788)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:233)
       at android.app.ActivityThread.main(ActivityThread.java:8063)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:631)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:978)
```

### Solution

A null check with a new error code

### Alternative solutions considered

Possibly a more robust solution would be an exponential backoff waiting for the activity to be re-attached with a timeout. Given the maturity of this library though it seems (from what I can see) this issue is very rare, and adding more complexity seems unneeded. Handling it elegently seems sufficient to me.