### PR TITLE
[flutter_appauth] fix: change presentingViewController to topMost viewController

### DIFF
--- a/flutter_appauth/android/src/main/AndroidManifest.xml
+++ b/flutter_appauth/android/src/main/AndroidManifest.xml
@@ -5,5 +5,7 @@
     <activity android:name="net.openid.appauth.RedirectUriReceiverActivity"
       android:theme="@style/Theme.AppCompat.Translucent.NoTitleBar"
       tools:replace="android:theme" />
+    <activity android:name="AppAuthIntentLauncherActivity"
+        android:theme="@style/Theme.AppCompat.Translucent.NoTitleBar"/>
   </application>
 </manifest>

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/AppAuthIntentLauncherActivity.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/AppAuthIntentLauncherActivity.java
@@ -1,0 +1,37 @@
+package io.crossingthestreams.flutterappauth;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+public class AppAuthIntentLauncherActivity extends Activity {
+  static class IntentExtraKey {
+    static String INTENT = "intent";
+    static String REQUEST_CODE = "requestCode";
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    Intent intent = getIntent().getParcelableExtra(IntentExtraKey.INTENT);
+    if (intent != null) {
+      int requestCode = getIntent().getIntExtra(IntentExtraKey.REQUEST_CODE, 0);
+      startActivityForResult(intent, requestCode);
+    } else {
+      finish();
+    }
+  }
+
+  @Override
+  protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
+
+    finish();
+
+    FlutterAppauthPlugin flutterAppauthPlugin = FlutterAppauthPlugin.getInstance();
+    if (flutterAppauthPlugin != null) {
+      flutterAppauthPlugin.onActivityResult(requestCode, resultCode, data);
+    }
+  }
+}

--- a/flutter_appauth/lib/flutter_appauth.dart
+++ b/flutter_appauth/lib/flutter_appauth.dart
@@ -8,6 +8,7 @@ export 'package:flutter_appauth_platform_interface/flutter_appauth_platform_inte
         EndSessionRequest,
         EndSessionResponse,
         ExternalUserAgent,
+        FlutterAppAuthErrorCode,
         FlutterAppAuthOAuthError,
         FlutterAppAuthPlatformErrorDetails,
         FlutterAppAuthUserCancelledException,

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -2,8 +2,8 @@ name: flutter_appauth
 description: This plugin provides an abstraction around the Android and iOS
   AppAuth SDKs so it can be used to communicate with OAuth 2.0 and OpenID
   Connect providers
-version: 11.0.0
-homepage: https://github.com/MaikuB/flutter_appauth/tree/master/flutter_appauth
+version: 11.1.0
+homepage: https://github.com/plx-eva/flutter_appauth/tree/master/flutter_appauth
 
 environment:
   sdk: ^3.7.0
@@ -12,7 +12,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_appauth_platform_interface: ^11.0.0
+  flutter_appauth_platform_interface:
+    git:
+      url: https://github.com/plx-eva/flutter_appauth.git
+      ref: flutter_appauth_platform_interface-v11.1.0
+      path: flutter_appauth_platform_interface
 
 flutter:
   plugin:

--- a/flutter_appauth_platform_interface/lib/flutter_appauth_platform_interface.dart
+++ b/flutter_appauth_platform_interface/lib/flutter_appauth_platform_interface.dart
@@ -5,6 +5,7 @@ export 'src/authorization_token_request.dart';
 export 'src/authorization_token_response.dart';
 export 'src/end_session_request.dart';
 export 'src/end_session_response.dart';
+export 'src/error_codes.dart';
 export 'src/errors.dart';
 export 'src/external_user_agent.dart';
 export 'src/flutter_appauth_platform.dart';

--- a/flutter_appauth_platform_interface/lib/src/error_codes.dart
+++ b/flutter_appauth_platform_interface/lib/src/error_codes.dart
@@ -1,0 +1,62 @@
+/// Unified, platform-agnostic error codes for the `flutter_appauth` plugin.
+///
+/// These are the possible values of [FlutterAppAuthPlatformException.errorCode]
+/// and [FlutterAppAuthUserCancelledException.errorCode].
+///
+/// Codes are grouped into three categories:
+/// - **Operation codes**: what the plugin was doing when the error occurred.
+/// - **AppAuth SDK cause codes**: what the underlying AppAuth SDK reported.
+/// - **OAuth error codes**: error strings returned by the authorization server
+///   (matching RFC 6749 lowercase strings).
+class FlutterAppAuthErrorCode {
+  // ── Operation codes ───────────────────────────────────────────────────────
+  static const String discoveryFailed = 'discovery_failed';
+  static const String authorizeAndExchangeCodeFailed = 'authorize_and_exchange_code_failed';
+  static const String authorizeFailed = 'authorize_failed';
+  static const String tokenFailed = 'token_failed';
+  static const String endSessionFailed = 'end_session_failed';
+
+  /// Android only.
+  static const String nullIntent = 'null_intent';
+
+  /// Android only.
+  static const String invalidClaims = 'invalid_claims';
+
+  /// Android only.
+  static const String noBrowserAvailable = 'no_browser_available';
+
+  // ── AppAuth SDK cause codes ───────────────────────────────────────────────
+  static const String invalidDiscoveryDocument = 'invalid_discovery_document';
+  static const String userCancelled = 'user_cancelled';
+  static const String programCancelled = 'program_cancelled';
+  static const String networkError = 'network_error';
+  static const String appAuthServerError = 'appauth_server_error';
+  static const String jsonDeserializationError = 'json_deserialization_error';
+  static const String tokenResponseConstructionError = 'token_response_construction_error';
+
+  /// macOS only (NSWorkspace.openURL returned NO).
+  static const String browserOpenError = 'browser_open_error';
+
+  /// iOS only.
+  static const String tokenRefreshError = 'token_refresh_error';
+  static const String invalidRegistrationResponse = 'invalid_registration_response';
+
+  /// iOS only.
+  static const String jsonSerializationError = 'json_serialization_error';
+  static const String idTokenParsingError = 'id_token_parsing_error';
+  static const String idTokenValidationError = 'id_token_validation_error';
+
+  // ── OAuth error codes (from authorization server, per RFC 6749) ───────────
+  static const String oauthInvalidRequest = 'invalid_request';
+  static const String oauthUnauthorizedClient = 'unauthorized_client';
+  static const String oauthAccessDenied = 'access_denied';
+  static const String oauthUnsupportedResponseType = 'unsupported_response_type';
+  static const String oauthInvalidScope = 'invalid_scope';
+  static const String oauthServerError = 'server_error';
+  static const String oauthTemporarilyUnavailable = 'temporarily_unavailable';
+  static const String oauthInvalidClient = 'invalid_client';
+  static const String oauthInvalidGrant = 'invalid_grant';
+  static const String oauthUnsupportedGrantType = 'unsupported_grant_type';
+  static const String oauthInvalidRedirectUri = 'invalid_redirect_uri';
+  static const String oauthInvalidClientMetadata = 'invalid_client_metadata';
+}

--- a/flutter_appauth_platform_interface/lib/src/errors.dart
+++ b/flutter_appauth_platform_interface/lib/src/errors.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/services.dart';
 
+import 'error_codes.dart';
+
 /// The details of an error thrown from the underlying
 /// platform's AppAuth SDK
 class FlutterAppAuthPlatformErrorDetails {
@@ -27,6 +29,11 @@ class FlutterAppAuthPlatformErrorDetails {
   ///
   /// On iOS/macOS: depending on the error type, it will be values from [here](https://github.com/openid/AppAuth-iOS/blob/c89ed571ae140f8eb1142735e6e23d7bb8c34cb2/Sources/AppAuthCore/OIDError.h).
   /// On Android: one of the codes defined [here](https://github.com/openid/AppAuth-Android/blob/c6137b7db306d9c097c0d5763f3fb944cd0122d2/library/java/net/openid/appauth/AuthorizationException.java#L158).
+  ///
+  /// This is the low-level native AppAuth SDK code and is distinct from the
+  /// unified [FlutterAppAuthErrorCode] constants. Use
+  /// [FlutterAppAuthPlatformException.errorCode] for platform-agnostic error
+  /// handling.
   ///
   /// It's recommended to not use this unless needed. In most cases, errors
   /// can be handled using the [error] property.
@@ -104,12 +111,17 @@ class FlutterAppAuthUserCancelledException extends PlatformException {
     dynamic legacyDetails,
     super.stacktrace,
     required this.platformErrorDetails,
-  }) : super(
-          details: legacyDetails,
-        );
+  }) : super(details: legacyDetails);
 
   /// Details of the error from the underlying platform's AppAuth SDK.
   final FlutterAppAuthPlatformErrorDetails platformErrorDetails;
+
+  /// Always returns [FlutterAppAuthErrorCode.userCancelled].
+  ///
+  /// Catching [FlutterAppAuthUserCancelledException] itself is the primary
+  /// way to handle user cancellation; this property is provided for parity
+  /// with [FlutterAppAuthPlatformException.errorCode].
+  String get errorCode => FlutterAppAuthErrorCode.userCancelled;
 
   @override
   String toString() {
@@ -127,12 +139,34 @@ class FlutterAppAuthPlatformException extends PlatformException {
     dynamic legacyDetails,
     super.stacktrace,
     required this.platformErrorDetails,
-  }) : super(
-          details: legacyDetails,
-        );
+  }) : super(details: legacyDetails);
 
   /// Details of the error from the underlying platform's AppAuth SDK.
   final FlutterAppAuthPlatformErrorDetails platformErrorDetails;
+
+  /// A unified, platform-agnostic error code.
+  ///
+  /// Use [FlutterAppAuthErrorCode] constants to match against this value:
+  /// ```dart
+  /// } on FlutterAppAuthPlatformException catch (e) {
+  ///   switch (e.errorCode) {
+  ///     case FlutterAppAuthErrorCode.networkError:
+  ///       // handle network error
+  ///     case FlutterAppAuthErrorCode.tokenFailed:
+  ///       // token operation failed for an unmapped reason
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Resolution order:
+  /// 1. If the server returned an OAuth error string (e.g. `invalid_grant`),
+  ///    that string is returned directly — match it against
+  ///    [FlutterAppAuthErrorCode.oauthInvalidGrant] etc.
+  /// 2. If the native AppAuth SDK code maps to a known cause, the cause
+  ///    code is returned (e.g. [FlutterAppAuthErrorCode.networkError]).
+  /// 3. Falls back to the operation code from [PlatformException.code]
+  ///    (e.g. [FlutterAppAuthErrorCode.tokenFailed]).
+  String get errorCode => _resolveErrorCode(platformErrorDetails, code);
 }
 
 /// Represents OAuth error codes that can be returned by the authorization
@@ -148,3 +182,62 @@ class FlutterAppAuthOAuthError {
   static const String unsupportedGrantType = 'unsupported_grant_type';
   static const String invalidScope = 'invalid_scope';
 }
+
+String _resolveErrorCode(FlutterAppAuthPlatformErrorDetails details, String fallback) {
+  // 1. OAuth error string from server matches constants directly
+  final oauthError = details.error;
+  if (oauthError != null) return oauthError;
+
+  final nativeCode = int.tryParse(details.code ?? '');
+  if (nativeCode == null) return fallback;
+
+  final type = details.type;
+  if (type == null) return fallback;
+
+  // Android: type is a small integer string ("0" = general errors)
+  final androidType = int.tryParse(type);
+  if (androidType != null) {
+    if (androidType == 0) {
+      return _androidGeneralCode(nativeCode) ?? fallback;
+    }
+    return fallback;
+  }
+
+  // iOS/macOS: type is the NSError domain string
+  if (type == 'org.openid.appauth.general') {
+    return _iosGeneralCode(nativeCode) ?? fallback;
+  }
+  return fallback;
+}
+
+String? _androidGeneralCode(int code) => switch (code) {
+  0 => FlutterAppAuthErrorCode.invalidDiscoveryDocument,
+  1 => FlutterAppAuthErrorCode.userCancelled,
+  2 => FlutterAppAuthErrorCode.programCancelled,
+  3 => FlutterAppAuthErrorCode.networkError,
+  4 => FlutterAppAuthErrorCode.appAuthServerError,
+  5 => FlutterAppAuthErrorCode.jsonDeserializationError,
+  6 => FlutterAppAuthErrorCode.tokenResponseConstructionError,
+  7 => FlutterAppAuthErrorCode.invalidRegistrationResponse,
+  8 => FlutterAppAuthErrorCode.idTokenParsingError,
+  9 => FlutterAppAuthErrorCode.idTokenValidationError,
+  _ => null,
+};
+
+String? _iosGeneralCode(int code) => switch (code) {
+  -2 => FlutterAppAuthErrorCode.invalidDiscoveryDocument,
+  -3 => FlutterAppAuthErrorCode.userCancelled,
+  -4 => FlutterAppAuthErrorCode.programCancelled,
+  -5 => FlutterAppAuthErrorCode.networkError,
+  -6 => FlutterAppAuthErrorCode.appAuthServerError,
+  -7 => FlutterAppAuthErrorCode.jsonDeserializationError,
+  -8 => FlutterAppAuthErrorCode.tokenResponseConstructionError,
+  -9 => FlutterAppAuthErrorCode.browserOpenError,
+  -10 => FlutterAppAuthErrorCode.browserOpenError,
+  -11 => FlutterAppAuthErrorCode.tokenRefreshError,
+  -12 => FlutterAppAuthErrorCode.invalidRegistrationResponse,
+  -13 => FlutterAppAuthErrorCode.jsonSerializationError,
+  -14 => FlutterAppAuthErrorCode.idTokenParsingError,
+  -15 => FlutterAppAuthErrorCode.idTokenValidationError,
+  _ => null,
+};

--- a/flutter_appauth_platform_interface/pubspec.yaml
+++ b/flutter_appauth_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_appauth_platform_interface
 description: A common platform interface for the flutter_appauth plugin.
-version: 11.0.0
-homepage: https://github.com/MaikuB/flutter_appauth/tree/master/flutter_appauth_platform_interface
+version: 11.1.0
+homepage: https://github.com/plx-eva/flutter_appauth/tree/master/flutter_appauth_platform_interface
 
 environment:
   sdk: ^3.7.0

--- a/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
+++ b/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
@@ -170,6 +170,70 @@ void main() {
     });
   });
 
+  group('errorCode', () {
+    test('Android network error maps to network_error', () {
+      final details = FlutterAppAuthPlatformErrorDetails(
+        type: '0',
+        code: '3',
+      );
+      final exception = FlutterAppAuthPlatformException(
+        code: 'token_failed',
+        platformErrorDetails: details,
+      );
+      expect(exception.errorCode, FlutterAppAuthErrorCode.networkError);
+    });
+
+    test('iOS network error maps to network_error', () {
+      final details = FlutterAppAuthPlatformErrorDetails(
+        type: 'org.openid.appauth.general',
+        code: '-5',
+      );
+      final exception = FlutterAppAuthPlatformException(
+        code: 'token_failed',
+        platformErrorDetails: details,
+      );
+      expect(exception.errorCode, FlutterAppAuthErrorCode.networkError);
+    });
+
+    test('OAuth error string is returned directly', () {
+      final details = FlutterAppAuthPlatformErrorDetails(
+        type: '2',
+        code: '2002',
+        error: 'invalid_grant',
+      );
+      final exception = FlutterAppAuthPlatformException(
+        code: 'token_failed',
+        platformErrorDetails: details,
+      );
+      expect(exception.errorCode, FlutterAppAuthErrorCode.oauthInvalidGrant);
+    });
+
+    test('FlutterAppAuthUserCancelledException errorCode is user_cancelled',
+        () {
+      final details = FlutterAppAuthPlatformErrorDetails(
+        type: '0',
+        code: '1',
+      );
+      final exception = FlutterAppAuthUserCancelledException(
+        code: 'authorize_failed',
+        platformErrorDetails: details,
+      );
+      expect(exception.errorCode, FlutterAppAuthErrorCode.userCancelled);
+    });
+
+    test('unknown mapping falls back to operation code', () {
+      final details = FlutterAppAuthPlatformErrorDetails(
+        type: '99',
+        code: '999',
+      );
+      final exception = FlutterAppAuthPlatformException(
+        code: 'token_failed',
+        platformErrorDetails: details,
+      );
+      expect(exception.errorCode, 'token_failed');
+    });
+  });
+
   test('endSession', () async {
     await flutterAppAuth.endSession(EndSessionRequest(
         idTokenHint: 'someIdToken',


### PR DESCRIPTION
AppAuth Flutter plugin is currently using rootViewController as presentingViewController when it needs to present a ViewController (SafariVC) for authentication.

If there is some additional ViewController being presented on top of the root FlutterViewController, then the presentation will fail. In this case, using rootViewController will return the root, i.e. FlutterViewController, whose view is NOT in the window hierarchy because there is another viewController presented on top of it, then the system will raise the following error:

Attempt to present UIViewController on UIViewController whose view is not in the window hierarchy.

To avoid this issue, at any time, when needing to present a ViewController, we should instead retrieve and use the topMost viewController.