### PR TITLE
Add autoGenerateState flag to EndSessionRequest to control whether to auto-generate state parameter

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -287,6 +287,7 @@ public class FlutterAppauthPlugin
     final String idTokenHint = (String) arguments.get("idTokenHint");
     final String postLogoutRedirectUrl = (String) arguments.get("postLogoutRedirectUrl");
     final String state = (String) arguments.get("state");
+    final boolean autoGenerateState = (boolean) arguments.get("autoGenerateState");
     final boolean allowInsecureConnections = (boolean) arguments.get("allowInsecureConnections");
     final String issuer = (String) arguments.get("issuer");
     final String discoveryUrl = (String) arguments.get("discoveryUrl");
@@ -298,6 +299,7 @@ public class FlutterAppauthPlugin
         idTokenHint,
         postLogoutRedirectUrl,
         state,
+        autoGenerateState,
         issuer,
         discoveryUrl,
         allowInsecureConnections,
@@ -570,7 +572,7 @@ public class FlutterAppauthPlugin
           Uri.parse(endSessionRequestParameters.postLogoutRedirectUrl));
     }
 
-    if (endSessionRequestParameters.state != null) {
+    if (endSessionRequestParameters.state != null || !endSessionRequestParameters.autoGenerateState) {
       endSessionRequestBuilder.setState(endSessionRequestParameters.state);
     }
 
@@ -831,6 +833,7 @@ public class FlutterAppauthPlugin
     final String idTokenHint;
     final String postLogoutRedirectUrl;
     final String state;
+    final boolean autoGenerateState;
     final String issuer;
     final String discoveryUrl;
     final boolean allowInsecureConnections;
@@ -841,6 +844,7 @@ public class FlutterAppauthPlugin
         String idTokenHint,
         String postLogoutRedirectUrl,
         String state,
+        boolean autoGenerateState,
         String issuer,
         String discoveryUrl,
         boolean allowInsecureConnections,
@@ -849,6 +853,7 @@ public class FlutterAppauthPlugin
       this.idTokenHint = idTokenHint;
       this.postLogoutRedirectUrl = postLogoutRedirectUrl;
       this.state = state;
+      this.autoGenerateState = autoGenerateState;
       this.issuer = issuer;
       this.discoveryUrl = discoveryUrl;
       this.allowInsecureConnections = allowInsecureConnections;

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/AppAuthIOSAuthorization.m
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/AppAuthIOSAuthorization.m
@@ -120,7 +120,7 @@
           : nil;
 
   OIDEndSessionRequest *endSessionRequest =
-      requestParameters.state
+      (requestParameters.state != nil || !requestParameters.autoGenerateState)
           ? [[OIDEndSessionRequest alloc]
                 initWithConfiguration:serviceConfiguration
                           idTokenHint:requestParameters.idTokenHint

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.h
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.h
@@ -51,6 +51,7 @@ static NSString *const END_SESSION_ERROR_MESSAGE_FORMAT =
 @property(nonatomic, strong) NSString *idTokenHint;
 @property(nonatomic, strong) NSString *postLogoutRedirectUrl;
 @property(nonatomic, strong) NSString *state;
+@property(nonatomic, assign) BOOL autoGenerateState;
 @property(nonatomic, strong) NSString *issuer;
 @property(nonatomic, strong) NSString *discoveryUrl;
 @property(nonatomic, strong) NSDictionary *serviceConfigurationParameters;

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
@@ -103,6 +103,9 @@
       [ArgumentProcessor processArgumentValue:arguments
                                       withKey:@"postLogoutRedirectUrl"];
   _state = [ArgumentProcessor processArgumentValue:arguments withKey:@"state"];
+  NSNumber *autoGenerateStateValue =
+      [ArgumentProcessor processArgumentValue:arguments withKey:@"autoGenerateState"];
+  _autoGenerateState = autoGenerateStateValue ? [autoGenerateStateValue boolValue] : YES;
   _issuer = [ArgumentProcessor processArgumentValue:arguments
                                             withKey:@"issuer"];
   _discoveryUrl = [ArgumentProcessor processArgumentValue:arguments

--- a/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/AppAuthMacOSAuthorization.m
+++ b/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/AppAuthMacOSAuthorization.m
@@ -120,7 +120,7 @@
           : nil;
 
   OIDEndSessionRequest *endSessionRequest =
-      requestParameters.state
+      (requestParameters.state != nil || !requestParameters.autoGenerateState)
           ? [[OIDEndSessionRequest alloc]
                 initWithConfiguration:serviceConfiguration
                           idTokenHint:requestParameters.idTokenHint

--- a/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
+++ b/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
@@ -103,6 +103,9 @@
       [ArgumentProcessor processArgumentValue:arguments
                                       withKey:@"postLogoutRedirectUrl"];
   _state = [ArgumentProcessor processArgumentValue:arguments withKey:@"state"];
+  NSNumber *autoGenerateStateValue =
+      [ArgumentProcessor processArgumentValue:arguments withKey:@"autoGenerateState"];
+  _autoGenerateState = autoGenerateStateValue ? [autoGenerateStateValue boolValue] : YES;
   _issuer = [ArgumentProcessor processArgumentValue:arguments
                                             withKey:@"issuer"];
   _discoveryUrl = [ArgumentProcessor processArgumentValue:arguments

--- a/flutter_appauth_platform_interface/lib/src/end_session_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/end_session_request.dart
@@ -7,6 +7,7 @@ class EndSessionRequest with AcceptedAuthorizationServiceConfigurationDetails {
     this.idTokenHint,
     this.postLogoutRedirectUrl,
     this.state,
+    this.autoGenerateState = true,
     this.allowInsecureConnections = false,
     this.externalUserAgent = ExternalUserAgent.asWebAuthenticationSession,
     this.additionalParameters,
@@ -32,6 +33,17 @@ class EndSessionRequest with AcceptedAuthorizationServiceConfigurationDetails {
   final String? postLogoutRedirectUrl;
 
   final String? state;
+
+  /// Whether to to automatically generate a random state value when none is provided via [state].
+  /// Defaults to `true`.
+  ///
+  /// Set to `false` to explicitly omit the state parameter from the end-session
+  /// request. This is necessary when the IdP does not support or expect a state
+  /// value and rejects requests that include one.
+  ///
+  /// When [state] is explicitly provided this flag has no effect; the supplied
+  /// value is always used.
+  final bool autoGenerateState;
 
   /// Whether to allow non-HTTPS endpoints.
   ///

--- a/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
@@ -28,6 +28,7 @@ extension EndSessionRequestMapper on EndSessionRequest {
       'idTokenHint': idTokenHint,
       'postLogoutRedirectUrl': postLogoutRedirectUrl,
       'state': state,
+      'autoGenerateState': autoGenerateState,
       'allowInsecureConnections': allowInsecureConnections,
       'additionalParameters': additionalParameters,
       'issuer': issuer,


### PR DESCRIPTION
## Problem
Some Identity Providers reject the end-session request because AppAuth (Android, iOS, macOS) automatically generates a random `state` value by  default. When those IdPs do not echo the state back, response validation fails and the logout flow breaks.

  | \`state\` | \`autoGenerateState\` | Behaviour |
  |---|---|---|
  | `null` | `true` (default) | AppAuth auto-generates _state_ — **unchanged** |
  | `"value"` | `true` | Explicit non-empty "value" used as _state_ — **unchanged** |
  | `"value"` | `false` | Explicit non-empty "value" used as _state_ — **unchanged** |
  | `null` | `false` | State suppressed — no _state_ sent to IdP → state suppressed |

---
Fixes #646