### PR TITLE
Fix InsecureConnectionBuilder (Android) and add allowInsecureConnections support (iOS/macOS)

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/InsecureConnectionBuilder.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/InsecureConnectionBuilder.java
@@ -9,6 +9,12 @@ import net.openid.appauth.connectivity.ConnectionBuilder;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 public class InsecureConnectionBuilder implements ConnectionBuilder {
 
@@ -19,6 +25,21 @@ public class InsecureConnectionBuilder implements ConnectionBuilder {
   @NonNull
   @Override
   public HttpURLConnection openConnection(@NonNull Uri uri) throws IOException {
-    return (HttpURLConnection) new URL(uri.toString()).openConnection();
+    HttpURLConnection conn = (HttpURLConnection) new URL(uri.toString()).openConnection();
+    if (conn instanceof HttpsURLConnection) {
+      try {
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, new TrustManager[] { new X509TrustManager() {
+          public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+          public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+          public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
+        }}, new SecureRandom());
+        ((HttpsURLConnection) conn).setSSLSocketFactory(sslContext.getSocketFactory());
+        ((HttpsURLConnection) conn).setHostnameVerifier((hostname, session) -> true);
+      } catch (Exception e) {
+        throw new IOException("Failed to configure insecure connection", e);
+      }
+    }
+    return conn;
   }
 }

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.h
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.h
@@ -56,6 +56,7 @@ static NSString *const END_SESSION_ERROR_MESSAGE_FORMAT =
 @property(nonatomic, strong) NSDictionary *serviceConfigurationParameters;
 @property(nonatomic, strong) NSDictionary *additionalParameters;
 @property(nonatomic, strong) NSNumber *externalUserAgent;
+@property(nonatomic, assign) BOOL allowInsecureConnections;
 @end
 
 typedef NS_ENUM(NSInteger, ExternalUserAgent) {

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
@@ -2,6 +2,90 @@
 
 #import "FlutterAppauthPlugin_Private.h"
 
+#pragma mark - InsecureURLProtocol
+
+@interface InsecureURLProtocol : NSURLProtocol <NSURLSessionDataDelegate>
+@property (nonatomic, strong) NSURLSessionDataTask *dataTask;
+@property (nonatomic, strong) NSURLSession *session;
+@end
+
+static NSString *const kInsecureURLProtocolHandledKey = @"InsecureURLProtocolHandled";
+
+@implementation InsecureURLProtocol
+
++ (BOOL)canInitWithRequest:(NSURLRequest *)request {
+  return [self propertyForKey:kInsecureURLProtocolHandledKey inRequest:request] == nil;
+}
+
++ (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request {
+  return request;
+}
+
+- (void)startLoading {
+  NSMutableURLRequest *mutableRequest = [self.request mutableCopy];
+  [InsecureURLProtocol setProperty:@YES
+                            forKey:kInsecureURLProtocolHandledKey
+                         inRequest:mutableRequest];
+
+  NSURLSessionConfiguration *config =
+      [NSURLSessionConfiguration defaultSessionConfiguration];
+  config.protocolClasses = @[];
+
+  self.session = [NSURLSession sessionWithConfiguration:config
+                                               delegate:self
+                                          delegateQueue:[NSOperationQueue mainQueue]];
+  self.dataTask = [self.session dataTaskWithRequest:mutableRequest];
+  [self.dataTask resume];
+}
+
+- (void)stopLoading {
+  [self.dataTask cancel];
+}
+
+- (void)URLSession:(NSURLSession *)session
+    didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+      completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition,
+                                  NSURLCredential *_Nullable credential))completionHandler {
+  if (challenge.protectionSpace.authenticationMethod ==
+      NSURLAuthenticationMethodServerTrust) {
+    SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
+    completionHandler(NSURLSessionAuthChallengeUseCredential,
+                      [NSURLCredential credentialForTrust:serverTrust]);
+  } else {
+    completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+  }
+}
+
+- (void)URLSession:(NSURLSession *)session
+          dataTask:(NSURLSessionDataTask *)dataTask
+didReceiveResponse:(NSURLResponse *)response
+ completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler {
+  [self.client URLProtocol:self
+        didReceiveResponse:response
+        cacheStoragePolicy:NSURLCacheStorageNotAllowed];
+  completionHandler(NSURLSessionResponseAllow);
+}
+
+- (void)URLSession:(NSURLSession *)session
+          dataTask:(NSURLSessionDataTask *)dataTask
+    didReceiveData:(NSData *)data {
+  [self.client URLProtocol:self didLoadData:data];
+}
+
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+didCompleteWithError:(NSError *)error {
+  if (error) {
+    [self.client URLProtocol:self didFailWithError:error];
+  } else {
+    [self.client URLProtocolDidFinishLoading:self];
+  }
+}
+
+@end
+
+#pragma mark - ArgumentProcessor
+
 @interface ArgumentProcessor : NSObject
 + (id _Nullable)processArgumentValue:(NSDictionary *)arguments
                              withKey:(NSString *)key;
@@ -31,6 +115,7 @@
 @property(nonatomic, strong) NSDictionary *serviceConfigurationParameters;
 @property(nonatomic, strong) NSDictionary *additionalParameters;
 @property(nonatomic, strong) NSNumber *externalUserAgent;
+@property(nonatomic, assign) BOOL allowInsecureConnections;
 
 @end
 
@@ -67,6 +152,10 @@
   _externalUserAgent =
       [ArgumentProcessor processArgumentValue:arguments
                                       withKey:@"externalUserAgent"];
+  NSNumber *allowInsecure =
+      [ArgumentProcessor processArgumentValue:arguments
+                                      withKey:@"allowInsecureConnections"];
+  _allowInsecureConnections = allowInsecure ? [allowInsecure boolValue] : NO;
 }
 
 - (id)initWithArguments:(NSDictionary *)arguments {
@@ -116,6 +205,10 @@
   _externalUserAgent =
       [ArgumentProcessor processArgumentValue:arguments
                                       withKey:@"externalUserAgent"];
+  NSNumber *allowInsecure =
+      [ArgumentProcessor processArgumentValue:arguments
+                                      withKey:@"allowInsecureConnections"];
+  _allowInsecureConnections = allowInsecure ? [allowInsecure boolValue] : NO;
   return self;
 }
 @end
@@ -197,6 +290,17 @@ AppAuthAuthorization *authorization;
           forKey:@"response_mode"];
   }
 
+  if (requestParameters.allowInsecureConnections) {
+    [NSURLProtocol registerClass:[InsecureURLProtocol class]];
+  }
+
+  FlutterResult insecureResult = ^(id _Nullable value) {
+    if (requestParameters.allowInsecureConnections) {
+      [NSURLProtocol unregisterClass:[InsecureURLProtocol class]];
+    }
+    result(value);
+  };
+
   if (requestParameters.serviceConfigurationParameters != nil) {
     OIDServiceConfiguration *serviceConfiguration =
         [self processServiceConfigurationParameters:
@@ -209,7 +313,7 @@ AppAuthAuthorization *authorization;
                  redirectUrl:requestParameters.redirectUrl
         additionalParameters:requestParameters.additionalParameters
            externalUserAgent:requestParameters.externalUserAgent
-                      result:result
+                      result:insecureResult
                 exchangeCode:exchangeCode
                        nonce:requestParameters.nonce];
   } else if (requestParameters.discoveryUrl) {
@@ -224,7 +328,7 @@ AppAuthAuthorization *authorization;
                                              [self
                                                  finishWithDiscoveryError:error
                                                                    result:
-                                                                       result];
+                                                                       insecureResult];
                                              return;
                                            }
 
@@ -249,7 +353,7 @@ AppAuthAuthorization *authorization;
                                                   externalUserAgent:
                                                       requestParameters
                                                           .externalUserAgent
-                                                             result:result
+                                                             result:insecureResult
                                                        exchangeCode:exchangeCode
                                                               nonce:
                                                                   requestParameters
@@ -264,7 +368,7 @@ AppAuthAuthorization *authorization;
                                                 NSError *_Nullable error) {
                                      if (!configuration) {
                                        [self finishWithDiscoveryError:error
-                                                               result:result];
+                                                               result:insecureResult];
                                        return;
                                      }
 
@@ -289,7 +393,7 @@ AppAuthAuthorization *authorization;
                                                 externalUserAgent:
                                                     requestParameters
                                                         .externalUserAgent
-                                                           result:result
+                                                           result:insecureResult
                                                      exchangeCode:exchangeCode
                                                             nonce:
                                                                 requestParameters
@@ -334,13 +438,25 @@ AppAuthAuthorization *authorization;
                        result:(FlutterResult)result {
   TokenRequestParameters *requestParameters =
       [[TokenRequestParameters alloc] initWithArguments:arguments];
+
+  if (requestParameters.allowInsecureConnections) {
+    [NSURLProtocol registerClass:[InsecureURLProtocol class]];
+  }
+
+  FlutterResult insecureResult = ^(id _Nullable value) {
+    if (requestParameters.allowInsecureConnections) {
+      [NSURLProtocol unregisterClass:[InsecureURLProtocol class]];
+    }
+    result(value);
+  };
+
   if (requestParameters.serviceConfigurationParameters != nil) {
     OIDServiceConfiguration *serviceConfiguration =
         [self processServiceConfigurationParameters:
                   requestParameters.serviceConfigurationParameters];
     [self performTokenRequest:serviceConfiguration
             requestParameters:requestParameters
-                       result:result];
+                       result:insecureResult];
   } else if (requestParameters.discoveryUrl) {
     NSURL *discoveryUrl = [NSURL URLWithString:requestParameters.discoveryUrl];
 
@@ -354,7 +470,7 @@ AppAuthAuthorization *authorization;
                                              [self
                                                  finishWithDiscoveryError:error
                                                                    result:
-                                                                       result];
+                                                                       insecureResult];
                                              return;
                                            }
 
@@ -362,7 +478,7 @@ AppAuthAuthorization *authorization;
                                                performTokenRequest:configuration
                                                  requestParameters:
                                                      requestParameters
-                                                            result:result];
+                                                            result:insecureResult];
                                          }];
   } else {
     NSURL *issuerUrl = [NSURL URLWithString:requestParameters.issuer];
@@ -373,13 +489,13 @@ AppAuthAuthorization *authorization;
                                                 NSError *_Nullable error) {
                                      if (!configuration) {
                                        [self finishWithDiscoveryError:error
-                                                               result:result];
+                                                               result:insecureResult];
                                        return;
                                      }
 
                                      [self performTokenRequest:configuration
                                              requestParameters:requestParameters
-                                                        result:result];
+                                                        result:insecureResult];
                                    }];
   }
 }
@@ -388,6 +504,18 @@ AppAuthAuthorization *authorization;
                             result:(FlutterResult)result {
   EndSessionRequestParameters *requestParameters =
       [[EndSessionRequestParameters alloc] initWithArguments:arguments];
+
+  if (requestParameters.allowInsecureConnections) {
+    [NSURLProtocol registerClass:[InsecureURLProtocol class]];
+  }
+
+  FlutterResult insecureResult = ^(id _Nullable value) {
+    if (requestParameters.allowInsecureConnections) {
+      [NSURLProtocol unregisterClass:[InsecureURLProtocol class]];
+    }
+    result(value);
+  };
+
   if (requestParameters.serviceConfigurationParameters != nil) {
     OIDServiceConfiguration *serviceConfiguration =
         [self processServiceConfigurationParameters:
@@ -395,7 +523,7 @@ AppAuthAuthorization *authorization;
     _currentAuthorizationFlow =
         [authorization performEndSessionRequest:serviceConfiguration
                               requestParameters:requestParameters
-                                         result:result];
+                                         result:insecureResult];
   } else if (requestParameters.discoveryUrl) {
     NSURL *discoveryUrl = [NSURL URLWithString:requestParameters.discoveryUrl];
 
@@ -409,7 +537,7 @@ AppAuthAuthorization *authorization;
                                              [self
                                                  finishWithDiscoveryError:error
                                                                    result:
-                                                                       result];
+                                                                       insecureResult];
                                              return;
                                            }
 
@@ -420,7 +548,7 @@ AppAuthAuthorization *authorization;
                                                           requestParameters:
                                                               requestParameters
                                                                      result:
-                                                                         result];
+                                                                         insecureResult];
                                          }];
   } else {
     NSURL *issuerUrl = [NSURL URLWithString:requestParameters.issuer];
@@ -431,7 +559,7 @@ AppAuthAuthorization *authorization;
                                                 NSError *_Nullable error) {
                                      if (!configuration) {
                                        [self finishWithDiscoveryError:error
-                                                               result:result];
+                                                               result:insecureResult];
                                        return;
                                      }
 
@@ -441,7 +569,7 @@ AppAuthAuthorization *authorization;
                                                  configuration
                                                     requestParameters:
                                                         requestParameters
-                                                               result:result];
+                                                               result:insecureResult];
                                    }];
   }
 }

--- a/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
+++ b/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
@@ -2,6 +2,90 @@
 
 #import "FlutterAppauthPlugin_Private.h"
 
+#pragma mark - InsecureURLProtocol
+
+@interface InsecureURLProtocol : NSURLProtocol <NSURLSessionDataDelegate>
+@property (nonatomic, strong) NSURLSessionDataTask *dataTask;
+@property (nonatomic, strong) NSURLSession *session;
+@end
+
+static NSString *const kInsecureURLProtocolHandledKey = @"InsecureURLProtocolHandled";
+
+@implementation InsecureURLProtocol
+
++ (BOOL)canInitWithRequest:(NSURLRequest *)request {
+  return [self propertyForKey:kInsecureURLProtocolHandledKey inRequest:request] == nil;
+}
+
++ (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request {
+  return request;
+}
+
+- (void)startLoading {
+  NSMutableURLRequest *mutableRequest = [self.request mutableCopy];
+  [InsecureURLProtocol setProperty:@YES
+                            forKey:kInsecureURLProtocolHandledKey
+                         inRequest:mutableRequest];
+
+  NSURLSessionConfiguration *config =
+      [NSURLSessionConfiguration defaultSessionConfiguration];
+  config.protocolClasses = @[];
+
+  self.session = [NSURLSession sessionWithConfiguration:config
+                                               delegate:self
+                                          delegateQueue:[NSOperationQueue mainQueue]];
+  self.dataTask = [self.session dataTaskWithRequest:mutableRequest];
+  [self.dataTask resume];
+}
+
+- (void)stopLoading {
+  [self.dataTask cancel];
+}
+
+- (void)URLSession:(NSURLSession *)session
+    didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
+      completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition,
+                                  NSURLCredential *_Nullable credential))completionHandler {
+  if (challenge.protectionSpace.authenticationMethod ==
+      NSURLAuthenticationMethodServerTrust) {
+    SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
+    completionHandler(NSURLSessionAuthChallengeUseCredential,
+                      [NSURLCredential credentialForTrust:serverTrust]);
+  } else {
+    completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+  }
+}
+
+- (void)URLSession:(NSURLSession *)session
+          dataTask:(NSURLSessionDataTask *)dataTask
+didReceiveResponse:(NSURLResponse *)response
+ completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler {
+  [self.client URLProtocol:self
+        didReceiveResponse:response
+        cacheStoragePolicy:NSURLCacheStorageNotAllowed];
+  completionHandler(NSURLSessionResponseAllow);
+}
+
+- (void)URLSession:(NSURLSession *)session
+          dataTask:(NSURLSessionDataTask *)dataTask
+    didReceiveData:(NSData *)data {
+  [self.client URLProtocol:self didLoadData:data];
+}
+
+- (void)URLSession:(NSURLSession *)session
+              task:(NSURLSessionTask *)task
+didCompleteWithError:(NSError *)error {
+  if (error) {
+    [self.client URLProtocol:self didFailWithError:error];
+  } else {
+    [self.client URLProtocolDidFinishLoading:self];
+  }
+}
+
+@end
+
+#pragma mark - ArgumentProcessor
+
 @interface ArgumentProcessor : NSObject
 + (id _Nullable)processArgumentValue:(NSDictionary *)arguments
                              withKey:(NSString *)key;
@@ -31,6 +115,7 @@
 @property(nonatomic, strong) NSDictionary *serviceConfigurationParameters;
 @property(nonatomic, strong) NSDictionary *additionalParameters;
 @property(nonatomic, strong) NSNumber *externalUserAgent;
+@property(nonatomic, assign) BOOL allowInsecureConnections;
 
 @end
 
@@ -67,6 +152,10 @@
   _externalUserAgent =
       [ArgumentProcessor processArgumentValue:arguments
                                       withKey:@"externalUserAgent"];
+  NSNumber *allowInsecure =
+      [ArgumentProcessor processArgumentValue:arguments
+                                      withKey:@"allowInsecureConnections"];
+  _allowInsecureConnections = allowInsecure ? [allowInsecure boolValue] : NO;
 }
 
 - (id)initWithArguments:(NSDictionary *)arguments {
@@ -116,6 +205,10 @@
   _externalUserAgent =
       [ArgumentProcessor processArgumentValue:arguments
                                       withKey:@"externalUserAgent"];
+  NSNumber *allowInsecure =
+      [ArgumentProcessor processArgumentValue:arguments
+                                      withKey:@"allowInsecureConnections"];
+  _allowInsecureConnections = allowInsecure ? [allowInsecure boolValue] : NO;
   return self;
 }
 @end
@@ -196,6 +289,17 @@ AppAuthAuthorization *authorization;
           forKey:@"response_mode"];
   }
 
+  if (requestParameters.allowInsecureConnections) {
+    [NSURLProtocol registerClass:[InsecureURLProtocol class]];
+  }
+
+  FlutterResult insecureResult = ^(id _Nullable value) {
+    if (requestParameters.allowInsecureConnections) {
+      [NSURLProtocol unregisterClass:[InsecureURLProtocol class]];
+    }
+    result(value);
+  };
+
   if (requestParameters.serviceConfigurationParameters != nil) {
     OIDServiceConfiguration *serviceConfiguration =
         [self processServiceConfigurationParameters:
@@ -208,7 +312,7 @@ AppAuthAuthorization *authorization;
                  redirectUrl:requestParameters.redirectUrl
         additionalParameters:requestParameters.additionalParameters
            externalUserAgent:requestParameters.externalUserAgent
-                      result:result
+                      result:insecureResult
                 exchangeCode:exchangeCode
                        nonce:requestParameters.nonce];
   } else if (requestParameters.discoveryUrl) {
@@ -223,7 +327,7 @@ AppAuthAuthorization *authorization;
                                              [self
                                                  finishWithDiscoveryError:error
                                                                    result:
-                                                                       result];
+                                                                       insecureResult];
                                              return;
                                            }
 
@@ -248,7 +352,7 @@ AppAuthAuthorization *authorization;
                                                   externalUserAgent:
                                                       requestParameters
                                                           .externalUserAgent
-                                                             result:result
+                                                             result:insecureResult
                                                        exchangeCode:exchangeCode
                                                               nonce:
                                                                   requestParameters
@@ -263,7 +367,7 @@ AppAuthAuthorization *authorization;
                                                 NSError *_Nullable error) {
                                      if (!configuration) {
                                        [self finishWithDiscoveryError:error
-                                                               result:result];
+                                                               result:insecureResult];
                                        return;
                                      }
 
@@ -288,7 +392,7 @@ AppAuthAuthorization *authorization;
                                                 externalUserAgent:
                                                     requestParameters
                                                         .externalUserAgent
-                                                           result:result
+                                                           result:insecureResult
                                                      exchangeCode:exchangeCode
                                                             nonce:
                                                                 requestParameters
@@ -333,13 +437,25 @@ AppAuthAuthorization *authorization;
                        result:(FlutterResult)result {
   TokenRequestParameters *requestParameters =
       [[TokenRequestParameters alloc] initWithArguments:arguments];
+
+  if (requestParameters.allowInsecureConnections) {
+    [NSURLProtocol registerClass:[InsecureURLProtocol class]];
+  }
+
+  FlutterResult insecureResult = ^(id _Nullable value) {
+    if (requestParameters.allowInsecureConnections) {
+      [NSURLProtocol unregisterClass:[InsecureURLProtocol class]];
+    }
+    result(value);
+  };
+
   if (requestParameters.serviceConfigurationParameters != nil) {
     OIDServiceConfiguration *serviceConfiguration =
         [self processServiceConfigurationParameters:
                   requestParameters.serviceConfigurationParameters];
     [self performTokenRequest:serviceConfiguration
             requestParameters:requestParameters
-                       result:result];
+                       result:insecureResult];
   } else if (requestParameters.discoveryUrl) {
     NSURL *discoveryUrl = [NSURL URLWithString:requestParameters.discoveryUrl];
 
@@ -353,7 +469,7 @@ AppAuthAuthorization *authorization;
                                              [self
                                                  finishWithDiscoveryError:error
                                                                    result:
-                                                                       result];
+                                                                       insecureResult];
                                              return;
                                            }
 
@@ -361,7 +477,7 @@ AppAuthAuthorization *authorization;
                                                performTokenRequest:configuration
                                                  requestParameters:
                                                      requestParameters
-                                                            result:result];
+                                                            result:insecureResult];
                                          }];
   } else {
     NSURL *issuerUrl = [NSURL URLWithString:requestParameters.issuer];
@@ -372,13 +488,13 @@ AppAuthAuthorization *authorization;
                                                 NSError *_Nullable error) {
                                      if (!configuration) {
                                        [self finishWithDiscoveryError:error
-                                                               result:result];
+                                                               result:insecureResult];
                                        return;
                                      }
 
                                      [self performTokenRequest:configuration
                                              requestParameters:requestParameters
-                                                        result:result];
+                                                        result:insecureResult];
                                    }];
   }
 }
@@ -387,6 +503,18 @@ AppAuthAuthorization *authorization;
                             result:(FlutterResult)result {
   EndSessionRequestParameters *requestParameters =
       [[EndSessionRequestParameters alloc] initWithArguments:arguments];
+
+  if (requestParameters.allowInsecureConnections) {
+    [NSURLProtocol registerClass:[InsecureURLProtocol class]];
+  }
+
+  FlutterResult insecureResult = ^(id _Nullable value) {
+    if (requestParameters.allowInsecureConnections) {
+      [NSURLProtocol unregisterClass:[InsecureURLProtocol class]];
+    }
+    result(value);
+  };
+
   if (requestParameters.serviceConfigurationParameters != nil) {
     OIDServiceConfiguration *serviceConfiguration =
         [self processServiceConfigurationParameters:
@@ -394,7 +522,7 @@ AppAuthAuthorization *authorization;
     _currentAuthorizationFlow =
         [authorization performEndSessionRequest:serviceConfiguration
                               requestParameters:requestParameters
-                                         result:result];
+                                         result:insecureResult];
   } else if (requestParameters.discoveryUrl) {
     NSURL *discoveryUrl = [NSURL URLWithString:requestParameters.discoveryUrl];
 
@@ -408,7 +536,7 @@ AppAuthAuthorization *authorization;
                                              [self
                                                  finishWithDiscoveryError:error
                                                                    result:
-                                                                       result];
+                                                                       insecureResult];
                                              return;
                                            }
 
@@ -419,7 +547,7 @@ AppAuthAuthorization *authorization;
                                                           requestParameters:
                                                               requestParameters
                                                                      result:
-                                                                         result];
+                                                                         insecureResult];
                                          }];
   } else {
     NSURL *issuerUrl = [NSURL URLWithString:requestParameters.issuer];
@@ -430,7 +558,7 @@ AppAuthAuthorization *authorization;
                                                 NSError *_Nullable error) {
                                      if (!configuration) {
                                        [self finishWithDiscoveryError:error
-                                                               result:result];
+                                                               result:insecureResult];
                                        return;
                                      }
 
@@ -440,7 +568,7 @@ AppAuthAuthorization *authorization;
                                                  configuration
                                                     requestParameters:
                                                         requestParameters
-                                                               result:result];
+                                                               result:insecureResult];
                                    }];
   }
 }


### PR DESCRIPTION
## Summary

Fixes #386

The `allowInsecureConnections` parameter does not work on any platform:

- **Android**: `InsecureConnectionBuilder.openConnection()` is a no-op — it calls `URL.openConnection()` without any SSL/TLS configuration, so HTTPS connections still validate the certificate chain normally.
- **iOS/macOS**: The `allowInsecureConnections` parameter is completely ignored. There is no equivalent of `InsecureConnectionBuilder`, and no SSL bypass mechanism exists.

This makes it impossible to use the plugin against OIDC providers with self-signed certificates during development (e.g., local Keycloak instances).

## Changes

### Android
Replaced the no-op `InsecureConnectionBuilder.openConnection()` with a real implementation that:
- Creates an `SSLContext` with a trust-all `X509TrustManager`
- Sets a permissive `HostnameVerifier` on `HttpsURLConnection`
- Only applies when `allowInsecureConnections=true` (the existing routing in `FlutterAppauthPlugin` via `getConnectionBuilder()` is unchanged)

### iOS & macOS
Added `InsecureURLProtocol` (an `NSURLProtocol` subclass) that:
- Intercepts HTTPS requests when registered
- Creates a private `NSURLSession` with empty `protocolClasses` to avoid recursion
- Trusts all server certificates via `NSURLSessionAuthChallengeUseCredential`
- Is registered before and unregistered after each plugin method call, only when `allowInsecureConnections=true`

Also added `allowInsecureConnections` property to `TokenRequestParameters` and `EndSessionRequestParameters` on iOS/macOS (was previously only defined on Android).

## Testing

Verified on Android emulator against a local Keycloak instance with a self-signed certificate:
- Endpoint discovery
- Authorization + token exchange
- Token refresh
- End session (logout)

All operations succeed without "Network error" when `allowInsecureConnections=true`.

## Security Note

The SSL bypass is **only active** when `allowInsecureConnections=true` is explicitly passed by the caller. Production configurations use CA-signed certificates and `allowInsecureConnections=false` (the default), so this change has no production impact.