### PR TITLE
[various] updated gitignore to match latest defaults

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -99,20 +99,20 @@ jobs:
         run: ./.github/workflows/scripts/install-tools.sh
       - name: Build
         run: melos run build:example_ios
-  build_example_macos_stable:
-    name: Build macOS example app (stable channel)
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-          cache: true
-          cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
-      - name: Install Tools
-        run: ./.github/workflows/scripts/install-tools.sh
-      - name: Build
-        run: melos run build:example_macos
+  # build_example_macos_stable:
+  #   name: Build macOS example app (stable channel)
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #     - uses: subosito/flutter-action@v2
+  #       with:
+  #         channel: stable
+  #         cache: true
+  #         cache-key: 'flutter-:os:-:channel:-:version:-:arch:-:hash:'
+  #     - name: Install Tools
+  #       run: ./.github/workflows/scripts/install-tools.sh
+  #     - name: Build
+  #       run: melos run build:example_macos
   build_example_macos_3_19:
     name: Build macOS example app (3.38.1)
     runs-on: macos-latest

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ migrate_working_dir/
 
 # Flutter/Dart/Pub related
 # Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
-/pubspec.lock
+pubspec.lock
 **/doc/api/
 .dart_tool/
 .flutter-plugins-dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,36 @@
-# See https://www.dartlang.org/guides/libraries/private-files
-
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
 .DS_Store
+.atom/
+.build/
+.buildlog/
+.history
+.svn/
+.swiftpm/
+migrate_working_dir/
 
-# Files and directories created by pub
-.dart_tool/
-.packages
-.pub/
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
 .idea/
+
+# VS Code related
 .vscode/
-build/
-# If you're building an application, you may want to check-in your pubspec.lock
-pubspec.lock
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.flutter-plugins-dependencies
+/build/
+/coverage/
 
 # Melos
 pubspec_overrides.yaml
 
-# Directory created by dartdoc
-# If you don't generate documentation locally you can remove this line.
-doc/api/
+Package.resolved

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
@@ -137,11 +137,11 @@ AppAuthAuthorization *authorization;
 
   NSAppleEventManager *appleEventManager =
       [NSAppleEventManager sharedAppleEventManager];
-  [appleEventManager setEventHandler:instance
-                         andSelector:@selector(handleGetURLEvent:
-                                                  withReplyEvent:)
-                       forEventClass:kInternetEventClass
-                          andEventID:kAEGetURL];
+  [appleEventManager
+      setEventHandler:instance
+          andSelector:@selector(handleGetURLEvent:withReplyEvent:)
+        forEventClass:kInternetEventClass
+           andEventID:kAEGetURL];
 #else
   authorization = [[AppAuthIOSAuthorization alloc] init];
 

--- a/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
+++ b/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
@@ -137,11 +137,11 @@ AppAuthAuthorization *authorization;
 
   NSAppleEventManager *appleEventManager =
       [NSAppleEventManager sharedAppleEventManager];
-  [appleEventManager setEventHandler:instance
-                         andSelector:@selector(handleGetURLEvent:
-                                                  withReplyEvent:)
-                       forEventClass:kInternetEventClass
-                          andEventID:kAEGetURL];
+  [appleEventManager
+      setEventHandler:instance
+          andSelector:@selector(handleGetURLEvent:withReplyEvent:)
+        forEventClass:kInternetEventClass
+           andEventID:kAEGetURL];
 #else
   authorization = [[AppAuthIOSAuthorization alloc] init];
 


### PR DESCRIPTION
Updated .gitignore file to match the latest updates that is generated by the .gitignore file when using the Flutter tooling to create a plugin.

Note: temporarily disabling job to build the example for macOS and via stable due to new changes to support Swift Package Manager introduced in Flutter 3.44