### PR TITLE
[flutter_appauth] fix:missing a dependency on FlutterFramework

### DIFF
--- a/flutter_appauth/ios/flutter_appauth/Package.swift
+++ b/flutter_appauth/ios/flutter_appauth/Package.swift
@@ -11,11 +11,17 @@ let package = Package(
     products: [
         .library(name: "flutter-appauth", targets: ["flutter_appauth"])
     ],
-    dependencies: [.package(url: "https://github.com/openid/AppAuth-iOS", exact: "2.0.0")],
+    dependencies: [
+        .package(url: "https://github.com/openid/AppAuth-iOS", exact: "2.0.0"),
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
     targets: [
         .target(
             name: "flutter_appauth",
-            dependencies: [.product(name: "AppAuth", package: "AppAuth-iOS")],
+            dependencies: [
+                .product(name: "AppAuth", package: "AppAuth-iOS"),
+                .package(name: "FlutterFramework", path: "../FlutterFramework")
+            ],
             resources: [
                 .process("PrivacyInfo.xcprivacy")
             ],

--- a/flutter_appauth/ios/flutter_appauth/Package.swift
+++ b/flutter_appauth/ios/flutter_appauth/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
             name: "flutter_appauth",
             dependencies: [
                 .product(name: "AppAuth", package: "AppAuth-iOS"),
-                .package(name: "FlutterFramework", path: "../FlutterFramework")
+                .package(name: "FlutterFramework", package: "FlutterFramework")
             ],
             resources: [
                 .process("PrivacyInfo.xcprivacy")

--- a/flutter_appauth/ios/flutter_appauth/Package.swift
+++ b/flutter_appauth/ios/flutter_appauth/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
             name: "flutter_appauth",
             dependencies: [
                 .product(name: "AppAuth", package: "AppAuth-iOS"),
-                .package(name: "FlutterFramework", package: "FlutterFramework")
+                .product(name: "FlutterFramework", package: "FlutterFramework")
             ],
             resources: [
                 .process("PrivacyInfo.xcprivacy")

--- a/flutter_appauth/macos/flutter_appauth/Package.swift
+++ b/flutter_appauth/macos/flutter_appauth/Package.swift
@@ -11,11 +11,17 @@ let package = Package(
     products: [
         .library(name: "flutter-appauth", targets: ["flutter_appauth"])
     ],
-    dependencies: [.package(url: "https://github.com/openid/AppAuth-iOS", exact: "2.0.0")],
+    dependencies: [
+        .package(url: "https://github.com/openid/AppAuth-iOS", exact: "2.0.0"),
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
     targets: [
         .target(
             name: "flutter_appauth",
-            dependencies: [.product(name: "AppAuth", package: "AppAuth-iOS")],
+            dependencies: [
+                .product(name: "AppAuth", package: "AppAuth-iOS"),
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ],
             resources: [
                 .process("PrivacyInfo.xcprivacy")
             ],


### PR DESCRIPTION
Got the following warnings while running:

```
Plugin flutter_appauth has a Package.swift for ios but is missing a dependency on FlutterFramework. Add the following to your Package.swift dependencies:
    .package(name: "FlutterFramework", path: "../FlutterFramework")
And add FlutterFramework as a target dependency:
    .product(name: "FlutterFramework", package: "FlutterFramework")
See https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-plugin-authors for more information.
Plugin flutter_appauth has a Package.swift for macos but is missing a dependency on FlutterFramework. Add the following to your Package.swift dependencies:
    .package(name: "FlutterFramework", path: "../FlutterFramework")
And add FlutterFramework as a target dependency:
    .product(name: "FlutterFramework", package: "FlutterFramework")
```