### PR TITLE
[flutter_appauth] Refactor authorization handling to support multiple response types in OAuth flows

### DIFF
--- a/flutter_appauth/android/build.gradle
+++ b/flutter_appauth/android/build.gradle
@@ -40,4 +40,5 @@ android {
 
 dependencies {
     implementation 'net.openid:appauth:0.11.1'
+    implementation 'androidx.browser:browser:1.8.0'
 }

--- a/flutter_appauth/android/src/main/AndroidManifest.xml
+++ b/flutter_appauth/android/src/main/AndroidManifest.xml
@@ -3,7 +3,18 @@
   xmlns:tools="http://schemas.android.com/tools">
   <application>
     <activity android:name="net.openid.appauth.RedirectUriReceiverActivity"
-      android:theme="@style/Theme.AppCompat.Translucent.NoTitleBar"
-      tools:replace="android:theme" />
+      tools:node="remove" />
+
+    <activity
+      android:name=".FlutterAppAuthRedirectUriReceiverActivity"
+      android:exported="true"
+      android:theme="@style/Theme.AppCompat.Translucent.NoTitleBar">
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="${appAuthRedirectScheme}" />
+      </intent-filter>
+    </activity>
   </application>
 </manifest>

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppAuthRedirectUriReceiverActivity.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppAuthRedirectUriReceiverActivity.java
@@ -1,0 +1,29 @@
+package io.crossingthestreams.flutterappauth;
+
+import android.net.Uri;
+import android.os.Bundle;
+import androidx.appcompat.app.AppCompatActivity;
+import net.openid.appauth.AuthorizationManagementActivity;
+
+/**
+ * Receives OAuth redirect URIs for flutter_appauth.
+ *
+ * <p>Implicit flows ({@code id_token token}, etc.) are handled manually so query and fragment
+ * parameters are both parsed. Authorization code flows are forwarded to AppAuth as usual.
+ */
+public class FlutterAppAuthRedirectUriReceiverActivity extends AppCompatActivity {
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    Uri uri = getIntent() != null ? getIntent().getData() : null;
+    if (FlutterAppauthPlugin.handleManualImplicitRedirectUri(uri)) {
+      finish();
+      return;
+    }
+
+    startActivity(
+        AuthorizationManagementActivity.createResponseHandlingIntent(this, uri));
+    finish();
+  }
+}

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppAuthRedirectUriReceiverActivity.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppAuthRedirectUriReceiverActivity.java
@@ -10,6 +10,9 @@ import net.openid.appauth.AuthorizationManagementActivity;
  *
  * <p>Implicit flows ({@code id_token token}, etc.) are handled manually so query and fragment
  * parameters are both parsed. Authorization code flows are forwarded to AppAuth as usual.
+ *
+ * <p>{@link AuthorizationManagementActivity} is always notified so the browser tab opened during
+ * authorization is removed from the back stack.
  */
 public class FlutterAppAuthRedirectUriReceiverActivity extends AppCompatActivity {
   @Override
@@ -17,10 +20,7 @@ public class FlutterAppAuthRedirectUriReceiverActivity extends AppCompatActivity
     super.onCreate(savedInstanceState);
 
     Uri uri = getIntent() != null ? getIntent().getData() : null;
-    if (FlutterAppauthPlugin.handleManualImplicitRedirectUri(uri)) {
-      finish();
-      return;
-    }
+    FlutterAppauthPlugin.handleManualImplicitRedirectUri(uri);
 
     startActivity(
         AuthorizationManagementActivity.createResponseHandlingIntent(this, uri));

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -5,9 +5,11 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.browser.customtabs.CustomTabsIntent;
 
 import net.openid.appauth.AppAuthConfiguration;
 import net.openid.appauth.AuthorizationException;
@@ -30,6 +32,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -85,6 +88,8 @@ public class FlutterAppauthPlugin
   private final int RC_AUTH = 65031;
   private final int RC_END_SESSION = 65032;
 
+  private static @Nullable FlutterAppauthPlugin instance;
+
   private Context applicationContext;
   private Activity mainActivity;
   private PendingOperation pendingOperation;
@@ -94,6 +99,7 @@ public class FlutterAppauthPlugin
   private AuthorizationService insecureAuthorizationService;
 
   private void onAttachedToEngine(Context context, BinaryMessenger binaryMessenger) {
+    instance = this;
     this.applicationContext = context;
     createAuthorizationServices();
     final MethodChannel channel =
@@ -108,6 +114,9 @@ public class FlutterAppauthPlugin
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    if (instance == this) {
+      instance = null;
+    }
     disposeAuthorizationServices();
   }
 
@@ -221,6 +230,7 @@ public class FlutterAppauthPlugin
         (Map<String, String>) arguments.get("additionalParameters");
     allowInsecureConnections = (boolean) arguments.get("allowInsecureConnections");
     final String responseMode = (String) arguments.get("responseMode");
+    final ArrayList<String> responseTypes = (ArrayList<String>) arguments.get("responseTypes");
 
     return new AuthorizationTokenRequestParameters(
         clientId,
@@ -233,7 +243,8 @@ public class FlutterAppauthPlugin
         loginHint,
         nonce,
         promptValues,
-        responseMode);
+        responseMode,
+        responseTypes);
   }
 
   @SuppressWarnings("unchecked")
@@ -323,7 +334,8 @@ public class FlutterAppauthPlugin
           tokenRequestParameters.additionalParameters,
           exchangeCode,
           tokenRequestParameters.promptValues,
-          tokenRequestParameters.responseMode);
+          tokenRequestParameters.responseMode,
+          tokenRequestParameters.responseTypes);
     } else {
       AuthorizationServiceConfiguration.RetrieveConfigurationCallback callback =
           new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
@@ -342,7 +354,8 @@ public class FlutterAppauthPlugin
                     tokenRequestParameters.additionalParameters,
                     exchangeCode,
                     tokenRequestParameters.promptValues,
-                    tokenRequestParameters.responseMode);
+                    tokenRequestParameters.responseMode,
+                    tokenRequestParameters.responseTypes);
               } else {
                 finishWithDiscoveryError(ex);
               }
@@ -415,10 +428,15 @@ public class FlutterAppauthPlugin
       Map<String, String> additionalParameters,
       boolean exchangeCode,
       ArrayList<String> promptValues,
-      String responseMode) {
+      String responseMode,
+      ArrayList<String> responseTypes) {
+    final String responseType =
+        responseTypes != null && !responseTypes.isEmpty()
+            ? TextUtils.join(" ", responseTypes)
+            : ResponseTypeValues.CODE;
     AuthorizationRequest.Builder authRequestBuilder =
         new AuthorizationRequest.Builder(
-            serviceConfiguration, clientId, ResponseTypeValues.CODE, Uri.parse(redirectUrl));
+            serviceConfiguration, clientId, responseType, Uri.parse(redirectUrl));
 
     if (scopes != null && !scopes.isEmpty()) {
       authRequestBuilder.setScopes(scopes);
@@ -462,10 +480,26 @@ public class FlutterAppauthPlugin
     }
 
     AuthorizationService authorizationService = getAuthorizationService();
+    AuthorizationRequest authRequest = authRequestBuilder.build();
+
+    if (isManualImplicitResponseType(responseType)) {
+      pendingOperation.manualImplicit = true;
+      pendingOperation.expectedState = authRequest.state;
+      pendingOperation.expectedNonce = authRequest.nonce;
+
+      try {
+        CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
+        customTabsIntent.launchUrl(mainActivity, authRequest.toUri());
+      } catch (ActivityNotFoundException ex) {
+        finishWithError(NO_BROWSER_AVAILABLE_ERROR_CODE, NO_BROWSER_AVAILABLE_ERROR_FORMAT, ex);
+      } catch (NullPointerException ex) {
+        finishWithError(NULL_ACTIVITY_ERROR_CODE, NULL_ACTIVITY_ERROR_FORMAT, ex);
+      }
+      return;
+    }
 
     try {
-      Intent authIntent =
-          authorizationService.getAuthorizationRequestIntent(authRequestBuilder.build());
+      Intent authIntent = authorizationService.getAuthorizationRequestIntent(authRequest);
       mainActivity.startActivityForResult(
           authIntent, exchangeCode ? RC_AUTH_EXCHANGE_CODE : RC_AUTH);
     } catch (ActivityNotFoundException ex) {
@@ -473,6 +507,97 @@ public class FlutterAppauthPlugin
     } catch (NullPointerException ex) {
       finishWithError(NULL_ACTIVITY_ERROR_CODE, NULL_ACTIVITY_ERROR_FORMAT, ex);
     }
+  }
+
+  static boolean handleManualImplicitRedirectUri(@Nullable Uri uri) {
+    if (instance == null || instance.pendingOperation == null) {
+      return false;
+    }
+    return instance.processManualImplicitRedirectUri(uri);
+  }
+
+  private boolean isManualImplicitResponseType(@NonNull String responseType) {
+    return ResponseTypeValues.TOKEN.equals(responseType)
+        || ResponseTypeValues.ID_TOKEN.equals(responseType)
+        || "id_token token".equals(responseType)
+        || "token id_token".equals(responseType);
+  }
+
+  private boolean processManualImplicitRedirectUri(@Nullable Uri uri) {
+    if (pendingOperation == null || !pendingOperation.manualImplicit) {
+      return false;
+    }
+
+    if (uri == null) {
+      finishWithError(
+          NULL_INTENT_ERROR_CODE,
+          NULL_INTENT_ERROR_FORMAT,
+          null);
+      return true;
+    }
+
+    Map<String, String> params = parseUriParameters(uri);
+
+    if (params.containsKey("error")) {
+      String message =
+          params.containsKey("error_description")
+              ? params.get("error_description")
+              : params.get("error");
+      finishWithError(AUTHORIZE_ERROR_CODE, message, null);
+      return true;
+    }
+
+    String responseState = params.get("state");
+    if (pendingOperation.expectedState != null
+        && !pendingOperation.expectedState.equals(responseState)) {
+      finishWithError(
+          AUTHORIZE_ERROR_CODE,
+          "Response state param did not match request state",
+          null);
+      return true;
+    }
+
+    Map<String, Object> responseMap = new HashMap<>();
+    responseMap.put("authorizationAdditionalParameters", new HashMap<>());
+    if (params.containsKey("id_token")) {
+      responseMap.put("idToken", params.get("id_token"));
+    }
+    if (params.containsKey("access_token")) {
+      responseMap.put("accessToken", params.get("access_token"));
+    }
+    if (params.containsKey("code")) {
+      responseMap.put("authorizationCode", params.get("code"));
+    }
+    responseMap.put("nonce", pendingOperation.expectedNonce);
+    finishWithSuccess(responseMap);
+    return true;
+  }
+
+  private Map<String, String> parseUriParameters(@NonNull Uri uri) {
+    Map<String, String> params = new LinkedHashMap<>();
+    if (uri.getQuery() != null) {
+      params.putAll(parseParameterString(uri.getQuery()));
+    }
+    if (uri.getFragment() != null) {
+      params.putAll(parseParameterString(uri.getFragment()));
+    }
+    return params;
+  }
+
+  private Map<String, String> parseParameterString(@NonNull String parameterString) {
+    Map<String, String> params = new LinkedHashMap<>();
+    for (String pair : parameterString.split("&")) {
+      int separatorIndex = pair.indexOf('=');
+      if (separatorIndex == -1) {
+        continue;
+      }
+      String key = Uri.decode(pair.substring(0, separatorIndex));
+      String value = Uri.decode(pair.substring(separatorIndex + 1));
+      if (!key.isEmpty()) {
+        params.put(key, value);
+      }
+    }
+    return params;
   }
 
   private void performTokenRequest(
@@ -771,6 +896,8 @@ public class FlutterAppauthPlugin
     responseMap.put("codeVerifier", authResponse.request.codeVerifier);
     responseMap.put("nonce", authResponse.request.nonce);
     responseMap.put("authorizationCode", authResponse.authorizationCode);
+    responseMap.put("idToken", authResponse.idToken);
+    responseMap.put("accessToken", authResponse.accessToken);
     responseMap.put("authorizationAdditionalParameters", authResponse.additionalParameters);
     return responseMap;
   }
@@ -778,6 +905,9 @@ public class FlutterAppauthPlugin
   private class PendingOperation {
     final String method;
     final Result result;
+    boolean manualImplicit = false;
+    @Nullable String expectedState;
+    @Nullable String expectedNonce;
 
     PendingOperation(String method, Result result) {
       this.method = method;
@@ -861,6 +991,7 @@ public class FlutterAppauthPlugin
     final String loginHint;
     final ArrayList<String> promptValues;
     final String responseMode;
+    final ArrayList<String> responseTypes;
 
     private AuthorizationTokenRequestParameters(
         String clientId,
@@ -873,7 +1004,8 @@ public class FlutterAppauthPlugin
         String loginHint,
         String nonce,
         ArrayList<String> promptValues,
-        String responseMode) {
+        String responseMode,
+        ArrayList<String> responseTypes) {
       super(
           clientId,
           issuer,
@@ -890,6 +1022,7 @@ public class FlutterAppauthPlugin
       this.loginHint = loginHint;
       this.promptValues = promptValues;
       this.responseMode = responseMode;
+      this.responseTypes = responseTypes;
     }
   }
 }

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -9,7 +9,6 @@ import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.browser.customtabs.CustomTabsIntent;
 
 import net.openid.appauth.AppAuthConfiguration;
 import net.openid.appauth.AuthorizationException;
@@ -486,16 +485,6 @@ public class FlutterAppauthPlugin
       pendingOperation.manualImplicit = true;
       pendingOperation.expectedState = authRequest.state;
       pendingOperation.expectedNonce = authRequest.nonce;
-
-      try {
-        CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
-        customTabsIntent.launchUrl(mainActivity, authRequest.toUri());
-      } catch (ActivityNotFoundException ex) {
-        finishWithError(NO_BROWSER_AVAILABLE_ERROR_CODE, NO_BROWSER_AVAILABLE_ERROR_FORMAT, ex);
-      } catch (NullPointerException ex) {
-        finishWithError(NULL_ACTIVITY_ERROR_CODE, NULL_ACTIVITY_ERROR_FORMAT, ex);
-      }
-      return;
     }
 
     try {

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/AppAuthIOSAuthorization.m
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/AppAuthIOSAuthorization.m
@@ -1,6 +1,233 @@
 #import "AppAuthIOSAuthorization.h"
 
+#import <AuthenticationServices/AuthenticationServices.h>
+
+@interface AppAuthIOSAuthorization () <ASWebAuthenticationPresentationContextProviding>
+@property(nonatomic, strong) ASWebAuthenticationSession *manualAuthSession;
+@end
+
 @implementation AppAuthIOSAuthorization
+
+- (BOOL)shouldUsePkceForResponseTypes:(NSArray *)responseTypes {
+  if (responseTypes == nil || responseTypes.count == 0) {
+    return YES;
+  }
+  return [responseTypes containsObject:@"code"];
+}
+
+- (NSString *)responseTypeStringForResponseTypes:(NSArray *)responseTypes {
+  if (responseTypes != nil && responseTypes.count > 0) {
+    return [responseTypes componentsJoinedByString:@" "];
+  }
+  return OIDResponseTypeCode;
+}
+
+- (BOOL)isAppAuthSupportedResponseType:(NSString *)responseType {
+  NSString *codeIdToken = [@[OIDResponseTypeCode, OIDResponseTypeIDToken]
+      componentsJoinedByString:@" "];
+  NSString *idTokenCode = [@[OIDResponseTypeIDToken, OIDResponseTypeCode]
+      componentsJoinedByString:@" "];
+
+  return [responseType isEqualToString:OIDResponseTypeCode]
+         || [responseType isEqualToString:codeIdToken]
+         || [responseType isEqualToString:idTokenCode];
+}
+
+- (NSDictionary<NSString *, NSString *> *)
+    parseParametersFromString:(NSString *)parameterString {
+  NSMutableDictionary<NSString *, NSString *> *parameters =
+      [[NSMutableDictionary alloc] init];
+  for (NSString *pair in [parameterString componentsSeparatedByString:@"&"]) {
+    NSRange range = [pair rangeOfString:@"="];
+    if (range.location == NSNotFound) {
+      continue;
+    }
+    NSString *key =
+        [[pair substringToIndex:range.location] stringByRemovingPercentEncoding];
+    NSString *value =
+        [[pair substringFromIndex:range.location + 1]
+            stringByRemovingPercentEncoding];
+    if (key.length > 0) {
+      parameters[key] = value ?: @"";
+    }
+  }
+  return parameters;
+}
+
+- (NSDictionary<NSString *, NSString *> *)parametersFromCallbackURL:
+    (NSURL *)callbackURL {
+  if (callbackURL.fragment.length > 0) {
+    return [self parseParametersFromString:callbackURL.fragment];
+  }
+  if (callbackURL.query.length > 0) {
+    return [self parseParametersFromString:callbackURL.query];
+  }
+  return @{};
+}
+
+- (NSURL *)authorizationURLWithConfiguration:
+                (OIDServiceConfiguration *)serviceConfiguration
+                                    clientId:(NSString *)clientId
+                                      scopes:(NSArray *)scopes
+                                 redirectUrl:(NSString *)redirectUrl
+                                responseType:(NSString *)responseType
+                                       state:(NSString *)state
+                                       nonce:(NSString *)nonce
+                        additionalParameters:
+                            (NSDictionary *)additionalParameters {
+  NSMutableDictionary<NSString *, NSString *> *parameters =
+      [[NSMutableDictionary alloc] init];
+  parameters[@"client_id"] = clientId;
+  parameters[@"redirect_uri"] = redirectUrl;
+  parameters[@"response_type"] = responseType;
+  parameters[@"state"] = state;
+  parameters[@"nonce"] = nonce;
+
+  NSString *scope = [OIDScopeUtilities scopesWithArray:scopes];
+  if (scope.length > 0) {
+    parameters[@"scope"] = scope;
+  }
+
+  if (additionalParameters != nil) {
+    [parameters addEntriesFromDictionary:additionalParameters];
+  }
+
+  NSURLComponents *components = [NSURLComponents
+      componentsWithURL:serviceConfiguration.authorizationEndpoint
+                            resolvingAgainstBaseURL:NO];
+  NSMutableArray<NSURLQueryItem *> *queryItems =
+      [[NSMutableArray alloc] init];
+  [parameters
+      enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value,
+                                           BOOL *stop) {
+        [queryItems addObject:[NSURLQueryItem queryItemWithName:key
+                                                          value:value]];
+      }];
+  components.queryItems = queryItems;
+  return components.URL;
+}
+
+- (id<OIDExternalUserAgentSession>)
+    performManualImplicitAuthorization:
+        (OIDServiceConfiguration *)serviceConfiguration
+                              clientId:(NSString *)clientId
+                                scopes:(NSArray *)scopes
+                           redirectUrl:(NSString *)redirectUrl
+                          responseType:(NSString *)responseType
+                                 state:(NSString *)state
+                                 nonce:(NSString *)nonce
+                  additionalParameters:(NSDictionary *)additionalParameters
+                     externalUserAgent:(NSNumber *)externalUserAgent
+                                result:(FlutterResult)result {
+  NSURL *authorizationURL =
+      [self authorizationURLWithConfiguration:serviceConfiguration
+                                     clientId:clientId
+                                       scopes:scopes
+                                  redirectUrl:redirectUrl
+                                 responseType:responseType
+                                        state:state
+                                        nonce:nonce
+                         additionalParameters:additionalParameters];
+  NSURL *redirectNSURL = [NSURL URLWithString:redirectUrl];
+  NSString *callbackScheme = redirectNSURL.scheme;
+  if (authorizationURL == nil || callbackScheme.length == 0) {
+    [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                            message:@"Invalid authorization URL or redirect scheme"
+                             result:result
+                              error:nil];
+    return nil;
+  }
+
+  if (@available(iOS 12.0, *)) {
+    __weak AppAuthIOSAuthorization *weakSelf = self;
+    ASWebAuthenticationSession *session =
+        [[ASWebAuthenticationSession alloc]
+                  initWithURL:authorizationURL
+            callbackURLScheme:callbackScheme
+            completionHandler:^(NSURL *_Nullable callbackURL,
+                                NSError *_Nullable error) {
+              __strong AppAuthIOSAuthorization *strongSelf = weakSelf;
+              if (!strongSelf) {
+                return;
+              }
+              strongSelf.manualAuthSession = nil;
+
+              if (callbackURL == nil) {
+                [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                                        message:[FlutterAppAuth
+                                                    formatMessageWithError:
+                                                        AUTHORIZE_ERROR_MESSAGE_FORMAT
+                                                                         error:error]
+                                         result:result
+                                          error:error];
+                return;
+              }
+
+              NSDictionary<NSString *, NSString *> *tokenParameters =
+                  [strongSelf parametersFromCallbackURL:callbackURL];
+              if (tokenParameters[@"error"] != nil) {
+                NSString *message = tokenParameters[@"error_description"]
+                                        ?: tokenParameters[@"error"];
+                [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                                        message:message
+                                         result:result
+                                          error:nil];
+                return;
+              }
+
+              NSString *responseState = tokenParameters[@"state"];
+              if (state.length > 0 &&
+                  ![state isEqualToString:responseState ?: @""]) {
+                [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                                        message:@"Response state param did not "
+                                                @"match request state"
+                                         result:result
+                                          error:nil];
+                return;
+              }
+
+              NSMutableDictionary *processedResponse =
+                  [[NSMutableDictionary alloc] init];
+              [processedResponse setObject:@{} forKey:@"authorizationAdditionalParameters"];
+              if (tokenParameters[@"id_token"] != nil) {
+                processedResponse[@"idToken"] = tokenParameters[@"id_token"];
+              }
+              if (tokenParameters[@"access_token"] != nil) {
+                processedResponse[@"accessToken"] =
+                    tokenParameters[@"access_token"];
+              }
+              if (tokenParameters[@"code"] != nil) {
+                processedResponse[@"authorizationCode"] = tokenParameters[@"code"];
+              }
+              processedResponse[@"nonce"] = nonce;
+              result(processedResponse);
+            }];
+
+    if (@available(iOS 13.0, *)) {
+      session.presentationContextProvider = self;
+      if ([externalUserAgent integerValue] ==
+          EphemeralASWebAuthenticationSession) {
+        session.prefersEphemeralWebBrowserSession = YES;
+      }
+    }
+
+    self.manualAuthSession = session;
+    if (![session start]) {
+      self.manualAuthSession = nil;
+      [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                              message:@"Unable to start web authentication session"
+                               result:result
+                                error:nil];
+    }
+  } else {
+    [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                            message:@"Implicit OAuth flows require iOS 12 or later"
+                             result:result
+                              error:nil];
+  }
+
+  return nil;
+}
 
 - (id<OIDExternalUserAgentSession>)
     performAuthorization:(OIDServiceConfiguration *)serviceConfiguration
@@ -12,10 +239,39 @@
        externalUserAgent:(NSNumber *)externalUserAgent
                   result:(FlutterResult)result
             exchangeCode:(BOOL)exchangeCode
-                   nonce:(NSString *)nonce {
-  NSString *codeVerifier = [OIDAuthorizationRequest generateCodeVerifier];
-  NSString *codeChallenge =
-      [OIDAuthorizationRequest codeChallengeS256ForVerifier:codeVerifier];
+                   nonce:(NSString *)nonce
+            responseTypes:(NSArray *)responseTypes {
+  NSString *responseTypeString =
+      [self responseTypeStringForResponseTypes:responseTypes];
+  NSString *requestNonce = nonce != nil
+                               ? nonce
+                               : [OIDAuthorizationRequest generateState];
+  NSString *state = [OIDAuthorizationRequest generateState];
+
+  if (![self isAppAuthSupportedResponseType:responseTypeString]) {
+    return [self performManualImplicitAuthorization:serviceConfiguration
+                                           clientId:clientId
+                                             scopes:scopes
+                                        redirectUrl:redirectUrl
+                                       responseType:responseTypeString
+                                              state:state
+                                              nonce:requestNonce
+                               additionalParameters:additionalParameters
+                                  externalUserAgent:externalUserAgent
+                                             result:result];
+  }
+
+  BOOL usePkce = [self shouldUsePkceForResponseTypes:responseTypes];
+  NSString *codeVerifier = nil;
+  NSString *codeChallenge = nil;
+  NSString *codeChallengeMethod = nil;
+
+  if (usePkce) {
+    codeVerifier = [OIDAuthorizationRequest generateCodeVerifier];
+    codeChallenge =
+        [OIDAuthorizationRequest codeChallengeS256ForVerifier:codeVerifier];
+    codeChallengeMethod = OIDOAuthorizationRequestCodeChallengeMethodS256;
+  }
 
   OIDAuthorizationRequest *request = [[OIDAuthorizationRequest alloc]
       initWithConfiguration:serviceConfiguration
@@ -23,15 +279,21 @@
                clientSecret:clientSecret
                       scope:[OIDScopeUtilities scopesWithArray:scopes]
                 redirectURL:[NSURL URLWithString:redirectUrl]
-               responseType:OIDResponseTypeCode
-                      state:[OIDAuthorizationRequest generateState]
-                      nonce:nonce != nil
-                                ? nonce
-                                : [OIDAuthorizationRequest generateState]
+               responseType:responseTypeString
+                      state:state
+                      nonce:requestNonce
                codeVerifier:codeVerifier
               codeChallenge:codeChallenge
-        codeChallengeMethod:OIDOAuthorizationRequestCodeChallengeMethodS256
+        codeChallengeMethod:codeChallengeMethod
        additionalParameters:additionalParameters];
+  if (request == nil) {
+    [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                            message:@"Unsupported OAuth response type"
+                             result:result
+                              error:nil];
+    return nil;
+  }
+
   UIViewController *rootViewController = [self rootViewController];
   if (exchangeCode) {
     id<OIDExternalUserAgent> agent =
@@ -81,19 +343,36 @@
                                [processedResponse
                                    setObject:authorizationResponse
                                                  .additionalParameters
+                                                 ?: @{}
                                       forKey:
                                           @"authorizationAdditionalParameters"];
-                               [processedResponse
-                                   setObject:authorizationResponse
-                                                 .authorizationCode
-                                      forKey:@"authorizationCode"];
-                               [processedResponse
-                                   setObject:authorizationResponse.request
-                                                 .codeVerifier
-                                      forKey:@"codeVerifier"];
-                               [processedResponse
-                                   setObject:authorizationResponse.request.nonce
-                                      forKey:@"nonce"];
+                               if (authorizationResponse.authorizationCode) {
+                                 [processedResponse
+                                     setObject:authorizationResponse
+                                                   .authorizationCode
+                                        forKey:@"authorizationCode"];
+                               }
+                               if (authorizationResponse.request.codeVerifier) {
+                                 [processedResponse
+                                     setObject:authorizationResponse.request
+                                                   .codeVerifier
+                                        forKey:@"codeVerifier"];
+                               }
+                               if (authorizationResponse.request.nonce) {
+                                 [processedResponse
+                                     setObject:authorizationResponse.request.nonce
+                                        forKey:@"nonce"];
+                               }
+                               if (authorizationResponse.idToken) {
+                                 [processedResponse
+                                     setObject:authorizationResponse.idToken
+                                        forKey:@"idToken"];
+                               }
+                               if (authorizationResponse.accessToken) {
+                                 [processedResponse
+                                     setObject:authorizationResponse.accessToken
+                                        forKey:@"accessToken"];
+                               }
                                result(processedResponse);
                              } else {
                                [FlutterAppAuth
@@ -189,6 +468,11 @@
         .firstObject.rootViewController;
   }
   return [UIApplication sharedApplication].delegate.window.rootViewController;
+}
+
+- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:
+    (ASWebAuthenticationSession *)session API_AVAILABLE(ios(13.0)) {
+  return [self rootViewController].view.window;
 }
 
 @end

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.h
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.h
@@ -59,7 +59,7 @@ static NSString *const END_SESSION_ERROR_MESSAGE_FORMAT =
 @end
 
 typedef NS_ENUM(NSInteger, ExternalUserAgent) {
-  ASWebAuthenticationSession,
+  DefaultASWebAuthenticationSession,
   EphemeralASWebAuthenticationSession,
   SafariViewController
 };
@@ -76,7 +76,8 @@ typedef NS_ENUM(NSInteger, ExternalUserAgent) {
        externalUserAgent:(NSNumber *)externalUserAgent
                   result:(FlutterResult)result
             exchangeCode:(BOOL)exchangeCode
-                   nonce:(NSString *)nonce;
+                   nonce:(NSString *)nonce
+            responseTypes:(NSArray *)responseTypes;
 
 - (id<OIDExternalUserAgentSession>)
     performEndSessionRequest:(OIDServiceConfiguration *)serviceConfiguration

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.m
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.m
@@ -135,7 +135,8 @@
        externalUserAgent:(NSNumber *)externalUserAgent
                   result:(FlutterResult)result
             exchangeCode:(BOOL)exchangeCode
-                   nonce:(NSString *)nonce {
+                   nonce:(NSString *)nonce
+            responseTypes:(NSArray *)responseTypes {
   return nil;
 }
 

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
@@ -80,6 +80,7 @@
 @property(nonatomic, strong) NSString *loginHint;
 @property(nonatomic, strong) NSArray *promptValues;
 @property(nonatomic, strong) NSString *responseMode;
+@property(nonatomic, strong) NSArray *responseTypes;
 @end
 
 @implementation AuthorizationTokenRequestParameters
@@ -91,6 +92,8 @@
                                                   withKey:@"promptValues"];
   _responseMode = [ArgumentProcessor processArgumentValue:arguments
                                                   withKey:@"responseMode"];
+  _responseTypes = [ArgumentProcessor processArgumentValue:arguments
+                                                  withKey:@"responseTypes"];
   return self;
 }
 @end
@@ -211,7 +214,8 @@ AppAuthAuthorization *authorization;
            externalUserAgent:requestParameters.externalUserAgent
                       result:result
                 exchangeCode:exchangeCode
-                       nonce:requestParameters.nonce];
+                       nonce:requestParameters.nonce
+                responseTypes:requestParameters.responseTypes];
   } else if (requestParameters.discoveryUrl) {
     NSURL *discoveryUrl = [NSURL URLWithString:requestParameters.discoveryUrl];
     [OIDAuthorizationService
@@ -253,7 +257,10 @@ AppAuthAuthorization *authorization;
                                                        exchangeCode:exchangeCode
                                                               nonce:
                                                                   requestParameters
-                                                                      .nonce];
+                                                                      .nonce
+                                                       responseTypes:
+                                                           requestParameters
+                                                               .responseTypes];
                                          }];
   } else {
     NSURL *issuerUrl = [NSURL URLWithString:requestParameters.issuer];
@@ -293,7 +300,10 @@ AppAuthAuthorization *authorization;
                                                      exchangeCode:exchangeCode
                                                             nonce:
                                                                 requestParameters
-                                                                    .nonce];
+                                                                    .nonce
+                                                     responseTypes:
+                                                         requestParameters
+                                                             .responseTypes];
                                    }];
   }
 }

--- a/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/AppAuthMacOSAuthorization.m
+++ b/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/AppAuthMacOSAuthorization.m
@@ -1,6 +1,231 @@
 #import "AppAuthMacOSAuthorization.h"
 
+#import <AuthenticationServices/AuthenticationServices.h>
+
+@interface AppAuthMacOSAuthorization () <ASWebAuthenticationPresentationContextProviding>
+@property(nonatomic, strong) ASWebAuthenticationSession *manualAuthSession;
+@end
+
 @implementation AppAuthMacOSAuthorization
+
+- (BOOL)shouldUsePkceForResponseTypes:(NSArray *)responseTypes {
+  if (responseTypes == nil || responseTypes.count == 0) {
+    return YES;
+  }
+  return [responseTypes containsObject:@"code"];
+}
+
+- (NSString *)responseTypeStringForResponseTypes:(NSArray *)responseTypes {
+  if (responseTypes != nil && responseTypes.count > 0) {
+    return [responseTypes componentsJoinedByString:@" "];
+  }
+  return OIDResponseTypeCode;
+}
+
+- (BOOL)isAppAuthSupportedResponseType:(NSString *)responseType {
+  NSString *codeIdToken = [@[OIDResponseTypeCode, OIDResponseTypeIDToken]
+      componentsJoinedByString:@" "];
+  NSString *idTokenCode = [@[OIDResponseTypeIDToken, OIDResponseTypeCode]
+      componentsJoinedByString:@" "];
+
+  return [responseType isEqualToString:OIDResponseTypeCode]
+         || [responseType isEqualToString:codeIdToken]
+         || [responseType isEqualToString:idTokenCode];
+}
+
+- (NSDictionary<NSString *, NSString *> *)
+    parseParametersFromString:(NSString *)parameterString {
+  NSMutableDictionary<NSString *, NSString *> *parameters =
+      [[NSMutableDictionary alloc] init];
+  for (NSString *pair in [parameterString componentsSeparatedByString:@"&"]) {
+    NSRange range = [pair rangeOfString:@"="];
+    if (range.location == NSNotFound) {
+      continue;
+    }
+    NSString *key =
+        [[pair substringToIndex:range.location] stringByRemovingPercentEncoding];
+    NSString *value =
+        [[pair substringFromIndex:range.location + 1]
+            stringByRemovingPercentEncoding];
+    if (key.length > 0) {
+      parameters[key] = value ?: @"";
+    }
+  }
+  return parameters;
+}
+
+- (NSDictionary<NSString *, NSString *> *)parametersFromCallbackURL:
+    (NSURL *)callbackURL {
+  if (callbackURL.fragment.length > 0) {
+    return [self parseParametersFromString:callbackURL.fragment];
+  }
+  if (callbackURL.query.length > 0) {
+    return [self parseParametersFromString:callbackURL.query];
+  }
+  return @{};
+}
+
+- (NSURL *)authorizationURLWithConfiguration:
+                (OIDServiceConfiguration *)serviceConfiguration
+                                    clientId:(NSString *)clientId
+                                      scopes:(NSArray *)scopes
+                                 redirectUrl:(NSString *)redirectUrl
+                                responseType:(NSString *)responseType
+                                       state:(NSString *)state
+                                       nonce:(NSString *)nonce
+                        additionalParameters:
+                            (NSDictionary *)additionalParameters {
+  NSMutableDictionary<NSString *, NSString *> *parameters =
+      [[NSMutableDictionary alloc] init];
+  parameters[@"client_id"] = clientId;
+  parameters[@"redirect_uri"] = redirectUrl;
+  parameters[@"response_type"] = responseType;
+  parameters[@"state"] = state;
+  parameters[@"nonce"] = nonce;
+
+  NSString *scope = [OIDScopeUtilities scopesWithArray:scopes];
+  if (scope.length > 0) {
+    parameters[@"scope"] = scope;
+  }
+
+  if (additionalParameters != nil) {
+    [parameters addEntriesFromDictionary:additionalParameters];
+  }
+
+  NSURLComponents *components = [NSURLComponents
+      componentsWithURL:serviceConfiguration.authorizationEndpoint
+                            resolvingAgainstBaseURL:NO];
+  NSMutableArray<NSURLQueryItem *> *queryItems =
+      [[NSMutableArray alloc] init];
+  [parameters
+      enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value,
+                                           BOOL *stop) {
+        [queryItems addObject:[NSURLQueryItem queryItemWithName:key
+                                                          value:value]];
+      }];
+  components.queryItems = queryItems;
+  return components.URL;
+}
+
+- (id<OIDExternalUserAgentSession>)
+    performManualImplicitAuthorization:
+        (OIDServiceConfiguration *)serviceConfiguration
+                              clientId:(NSString *)clientId
+                                scopes:(NSArray *)scopes
+                           redirectUrl:(NSString *)redirectUrl
+                          responseType:(NSString *)responseType
+                                 state:(NSString *)state
+                                 nonce:(NSString *)nonce
+                  additionalParameters:(NSDictionary *)additionalParameters
+                     externalUserAgent:(NSNumber *)externalUserAgent
+                                result:(FlutterResult)result {
+  NSURL *authorizationURL =
+      [self authorizationURLWithConfiguration:serviceConfiguration
+                                     clientId:clientId
+                                       scopes:scopes
+                                  redirectUrl:redirectUrl
+                                 responseType:responseType
+                                        state:state
+                                        nonce:nonce
+                         additionalParameters:additionalParameters];
+  NSURL *redirectNSURL = [NSURL URLWithString:redirectUrl];
+  NSString *callbackScheme = redirectNSURL.scheme;
+  if (authorizationURL == nil || callbackScheme.length == 0) {
+    [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                            message:@"Invalid authorization URL or redirect scheme"
+                             result:result
+                              error:nil];
+    return nil;
+  }
+
+  if (@available(macOS 10.15, *)) {
+    __weak AppAuthMacOSAuthorization *weakSelf = self;
+    ASWebAuthenticationSession *session =
+        [[ASWebAuthenticationSession alloc]
+                  initWithURL:authorizationURL
+            callbackURLScheme:callbackScheme
+            completionHandler:^(NSURL *_Nullable callbackURL,
+                                NSError *_Nullable error) {
+              __strong AppAuthMacOSAuthorization *strongSelf = weakSelf;
+              if (!strongSelf) {
+                return;
+              }
+              strongSelf.manualAuthSession = nil;
+
+              if (callbackURL == nil) {
+                [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                                        message:[FlutterAppAuth
+                                                    formatMessageWithError:
+                                                        AUTHORIZE_ERROR_MESSAGE_FORMAT
+                                                                         error:error]
+                                         result:result
+                                          error:error];
+                return;
+              }
+
+              NSDictionary<NSString *, NSString *> *tokenParameters =
+                  [strongSelf parametersFromCallbackURL:callbackURL];
+              if (tokenParameters[@"error"] != nil) {
+                NSString *message = tokenParameters[@"error_description"]
+                                        ?: tokenParameters[@"error"];
+                [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                                        message:message
+                                         result:result
+                                          error:nil];
+                return;
+              }
+
+              NSString *responseState = tokenParameters[@"state"];
+              if (state.length > 0 &&
+                  ![state isEqualToString:responseState ?: @""]) {
+                [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                                        message:@"Response state param did not "
+                                                @"match request state"
+                                         result:result
+                                          error:nil];
+                return;
+              }
+
+              NSMutableDictionary *processedResponse =
+                  [[NSMutableDictionary alloc] init];
+              [processedResponse setObject:@{} forKey:@"authorizationAdditionalParameters"];
+              if (tokenParameters[@"id_token"] != nil) {
+                processedResponse[@"idToken"] = tokenParameters[@"id_token"];
+              }
+              if (tokenParameters[@"access_token"] != nil) {
+                processedResponse[@"accessToken"] =
+                    tokenParameters[@"access_token"];
+              }
+              if (tokenParameters[@"code"] != nil) {
+                processedResponse[@"authorizationCode"] = tokenParameters[@"code"];
+              }
+              processedResponse[@"nonce"] = nonce;
+              result(processedResponse);
+            }];
+
+    session.presentationContextProvider = self;
+    if ([externalUserAgent integerValue] ==
+        EphemeralASWebAuthenticationSession) {
+      session.prefersEphemeralWebBrowserSession = YES;
+    }
+
+    self.manualAuthSession = session;
+    if (![session start]) {
+      self.manualAuthSession = nil;
+      [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                              message:@"Unable to start web authentication session"
+                               result:result
+                                error:nil];
+    }
+  } else {
+    [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                            message:@"Implicit OAuth flows require macOS 10.15 or later"
+                             result:result
+                              error:nil];
+  }
+
+  return nil;
+}
 
 - (id<OIDExternalUserAgentSession>)
     performAuthorization:(OIDServiceConfiguration *)serviceConfiguration
@@ -12,10 +237,39 @@
        externalUserAgent:(NSNumber *)externalUserAgent
                   result:(FlutterResult)result
             exchangeCode:(BOOL)exchangeCode
-                   nonce:(NSString *)nonce {
-  NSString *codeVerifier = [OIDAuthorizationRequest generateCodeVerifier];
-  NSString *codeChallenge =
-      [OIDAuthorizationRequest codeChallengeS256ForVerifier:codeVerifier];
+                   nonce:(NSString *)nonce
+            responseTypes:(NSArray *)responseTypes {
+  NSString *responseTypeString =
+      [self responseTypeStringForResponseTypes:responseTypes];
+  NSString *requestNonce = nonce != nil
+                               ? nonce
+                               : [OIDAuthorizationRequest generateState];
+  NSString *state = [OIDAuthorizationRequest generateState];
+
+  if (![self isAppAuthSupportedResponseType:responseTypeString]) {
+    return [self performManualImplicitAuthorization:serviceConfiguration
+                                           clientId:clientId
+                                             scopes:scopes
+                                        redirectUrl:redirectUrl
+                                       responseType:responseTypeString
+                                              state:state
+                                              nonce:requestNonce
+                               additionalParameters:additionalParameters
+                                  externalUserAgent:externalUserAgent
+                                             result:result];
+  }
+
+  BOOL usePkce = [self shouldUsePkceForResponseTypes:responseTypes];
+  NSString *codeVerifier = nil;
+  NSString *codeChallenge = nil;
+  NSString *codeChallengeMethod = nil;
+
+  if (usePkce) {
+    codeVerifier = [OIDAuthorizationRequest generateCodeVerifier];
+    codeChallenge =
+        [OIDAuthorizationRequest codeChallengeS256ForVerifier:codeVerifier];
+    codeChallengeMethod = OIDOAuthorizationRequestCodeChallengeMethodS256;
+  }
 
   OIDAuthorizationRequest *request = [[OIDAuthorizationRequest alloc]
       initWithConfiguration:serviceConfiguration
@@ -23,15 +277,21 @@
                clientSecret:clientSecret
                       scope:[OIDScopeUtilities scopesWithArray:scopes]
                 redirectURL:[NSURL URLWithString:redirectUrl]
-               responseType:OIDResponseTypeCode
-                      state:[OIDAuthorizationRequest generateState]
-                      nonce:nonce != nil
-                                ? nonce
-                                : [OIDAuthorizationRequest generateState]
+               responseType:responseTypeString
+                      state:state
+                      nonce:requestNonce
                codeVerifier:codeVerifier
               codeChallenge:codeChallenge
-        codeChallengeMethod:OIDOAuthorizationRequestCodeChallengeMethodS256
+        codeChallengeMethod:codeChallengeMethod
        additionalParameters:additionalParameters];
+  if (request == nil) {
+    [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE
+                            message:@"Unsupported OAuth response type"
+                             result:result
+                              error:nil];
+    return nil;
+  }
+
   NSWindow *keyWindow = [[NSApplication sharedApplication] keyWindow];
   if (exchangeCode) {
     NSObject<OIDExternalUserAgent> *agent =
@@ -81,19 +341,36 @@
                                [processedResponse
                                    setObject:authorizationResponse
                                                  .additionalParameters
+                                                 ?: @{}
                                       forKey:
                                           @"authorizationAdditionalParameters"];
-                               [processedResponse
-                                   setObject:authorizationResponse
-                                                 .authorizationCode
-                                      forKey:@"authorizationCode"];
-                               [processedResponse
-                                   setObject:authorizationResponse.request
-                                                 .codeVerifier
-                                      forKey:@"codeVerifier"];
-                               [processedResponse
-                                   setObject:authorizationResponse.request.nonce
-                                      forKey:@"nonce"];
+                               if (authorizationResponse.authorizationCode) {
+                                 [processedResponse
+                                     setObject:authorizationResponse
+                                                   .authorizationCode
+                                        forKey:@"authorizationCode"];
+                               }
+                               if (authorizationResponse.request.codeVerifier) {
+                                 [processedResponse
+                                     setObject:authorizationResponse.request
+                                                   .codeVerifier
+                                        forKey:@"codeVerifier"];
+                               }
+                               if (authorizationResponse.request.nonce) {
+                                 [processedResponse
+                                     setObject:authorizationResponse.request.nonce
+                                        forKey:@"nonce"];
+                               }
+                               if (authorizationResponse.idToken) {
+                                 [processedResponse
+                                     setObject:authorizationResponse.idToken
+                                        forKey:@"idToken"];
+                               }
+                               if (authorizationResponse.accessToken) {
+                                 [processedResponse
+                                     setObject:authorizationResponse.accessToken
+                                        forKey:@"accessToken"];
+                               }
                                result(processedResponse);
                              } else {
                                [FlutterAppAuth
@@ -137,6 +414,7 @@
   id<OIDExternalUserAgent> externalUserAgent =
       [self userAgentWithPresentingWindow:keyWindow
                         externalUserAgent:requestParameters.externalUserAgent];
+
   return [OIDAuthorizationService
       presentEndSessionRequest:endSessionRequest
              externalUserAgent:externalUserAgent
@@ -170,6 +448,11 @@
   }
   return [[OIDExternalUserAgentMac alloc]
       initWithPresentingWindow:presentingWindow];
+}
+
+- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:
+    (ASWebAuthenticationSession *)session API_AVAILABLE(macos(10.15)) {
+  return [[NSApplication sharedApplication] keyWindow];
 }
 
 @end

--- a/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.m
+++ b/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.m
@@ -135,7 +135,8 @@
        externalUserAgent:(NSNumber *)externalUserAgent
                   result:(FlutterResult)result
             exchangeCode:(BOOL)exchangeCode
-                   nonce:(NSString *)nonce {
+                   nonce:(NSString *)nonce
+            responseTypes:(NSArray *)responseTypes {
   return nil;
 }
 

--- a/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
+++ b/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
@@ -80,6 +80,7 @@
 @property(nonatomic, strong) NSString *loginHint;
 @property(nonatomic, strong) NSArray *promptValues;
 @property(nonatomic, strong) NSString *responseMode;
+@property(nonatomic, strong) NSArray *responseTypes;
 @end
 
 @implementation AuthorizationTokenRequestParameters
@@ -91,6 +92,8 @@
                                                   withKey:@"promptValues"];
   _responseMode = [ArgumentProcessor processArgumentValue:arguments
                                                   withKey:@"responseMode"];
+  _responseTypes = [ArgumentProcessor processArgumentValue:arguments
+                                                  withKey:@"responseTypes"];
   return self;
 }
 @end
@@ -210,7 +213,8 @@ AppAuthAuthorization *authorization;
            externalUserAgent:requestParameters.externalUserAgent
                       result:result
                 exchangeCode:exchangeCode
-                       nonce:requestParameters.nonce];
+                       nonce:requestParameters.nonce
+                responseTypes:requestParameters.responseTypes];
   } else if (requestParameters.discoveryUrl) {
     NSURL *discoveryUrl = [NSURL URLWithString:requestParameters.discoveryUrl];
     [OIDAuthorizationService
@@ -252,7 +256,10 @@ AppAuthAuthorization *authorization;
                                                        exchangeCode:exchangeCode
                                                               nonce:
                                                                   requestParameters
-                                                                      .nonce];
+                                                                      .nonce
+                                                       responseTypes:
+                                                           requestParameters
+                                                               .responseTypes];
                                          }];
   } else {
     NSURL *issuerUrl = [NSURL URLWithString:requestParameters.issuer];
@@ -292,7 +299,10 @@ AppAuthAuthorization *authorization;
                                                      exchangeCode:exchangeCode
                                                             nonce:
                                                                 requestParameters
-                                                                    .nonce];
+                                                                    .nonce
+                                                     responseTypes:
+                                                         requestParameters
+                                                             .responseTypes];
                                    }];
   }
 }

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -12,7 +12,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_appauth_platform_interface: ^12.0.1
+  flutter_appauth_platform_interface:
+    path: ../flutter_appauth_platform_interface
 
 flutter:
   plugin:

--- a/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
@@ -14,4 +14,9 @@ mixin AuthorizationParameters {
 
   /// Specifies the response mode to use.
   String? responseMode;
+
+  /// OAuth 2.0 / OpenID Connect response types (e.g. `['code']`, `['id_token', 'token']`).
+  ///
+  /// Joined with a space when sent to the authorization endpoint as `response_type`.
+  List<String>? responseTypes;
 }

--- a/flutter_appauth_platform_interface/lib/src/authorization_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_request.dart
@@ -21,6 +21,7 @@ class AuthorizationRequest extends CommonRequestDetails
         ExternalUserAgent.asWebAuthenticationSession,
     String? nonce,
     String? responseMode,
+    List<String>? responseTypes,
   }) {
     this.clientId = clientId;
     this.redirectUrl = redirectUrl;
@@ -35,6 +36,7 @@ class AuthorizationRequest extends CommonRequestDetails
     this.externalUserAgent = externalUserAgent;
     this.nonce = nonce;
     this.responseMode = responseMode;
+    this.responseTypes = responseTypes;
     assertConfigurationInfo();
   }
 }

--- a/flutter_appauth_platform_interface/lib/src/authorization_response.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_response.dart
@@ -4,6 +4,8 @@ class AuthorizationResponse {
     this.authorizationCode,
     this.codeVerifier,
     this.nonce,
+    this.idToken,
+    this.accessToken,
     this.authorizationAdditionalParameters,
   });
 
@@ -20,6 +22,12 @@ class AuthorizationResponse {
   ///
   /// Use this when exchanging the [authorizationCode] for a token.
   final String? nonce;
+
+  /// The ID token returned by implicit / hybrid authorization flows.
+  final String? idToken;
+
+  /// The access token returned by implicit / hybrid authorization flows.
+  final String? accessToken;
 
   /// Additional parameters included in the response.
   final Map<String, dynamic>? authorizationAdditionalParameters;

--- a/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
@@ -22,6 +22,7 @@ class AuthorizationTokenRequest extends TokenRequest
         ExternalUserAgent.asWebAuthenticationSession,
     super.nonce,
     String? responseMode,
+    List<String>? responseTypes,
   }) : super(
           grantType: GrantType.authorizationCode,
         ) {
@@ -29,5 +30,6 @@ class AuthorizationTokenRequest extends TokenRequest
     this.promptValues = promptValues;
     this.externalUserAgent = externalUserAgent;
     this.responseMode = responseMode;
+    this.responseTypes = responseTypes;
   }
 }

--- a/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
@@ -27,6 +27,8 @@ class MethodChannelFlutterAppAuth extends FlutterAppAuthPlatform {
       authorizationCode: result['authorizationCode'],
       codeVerifier: result['codeVerifier'],
       nonce: result['nonce'],
+      idToken: result['idToken'],
+      accessToken: result['accessToken'],
       authorizationAdditionalParameters:
           result['authorizationAdditionalParameters']?.cast<String, dynamic>(),
     );

--- a/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
@@ -101,5 +101,6 @@ Map<String, Object?> _convertAuthorizationParametersToMap(
     'promptValues': authorizationParameters.promptValues,
     'externalUserAgent': authorizationParameters.externalUserAgent?.index,
     'responseMode': authorizationParameters.responseMode,
+    'responseTypes': authorizationParameters.responseTypes,
   };
 }

--- a/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
+++ b/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
@@ -42,6 +42,37 @@ void main() {
               ExternalUserAgent.asWebAuthenticationSession.index,
           'promptValues': null,
           'responseMode': null,
+          'responseTypes': null,
+          'nonce': null,
+        })
+      ],
+    );
+  });
+
+  test('authorize with responseTypes', () async {
+    await flutterAppAuth.authorize(AuthorizationRequest(
+        'someClientId', 'someRedirectUrl',
+        discoveryUrl: 'someDiscoveryUrl',
+        responseTypes: ['id_token', 'token'],
+        responseMode: 'fragment'));
+    expect(
+      log,
+      <Matcher>[
+        isMethodCall('authorize', arguments: <String, Object?>{
+          'clientId': 'someClientId',
+          'issuer': null,
+          'redirectUrl': 'someRedirectUrl',
+          'discoveryUrl': 'someDiscoveryUrl',
+          'loginHint': null,
+          'scopes': null,
+          'serviceConfiguration': null,
+          'additionalParameters': null,
+          'allowInsecureConnections': false,
+          'externalUserAgent':
+              ExternalUserAgent.asWebAuthenticationSession.index,
+          'promptValues': null,
+          'responseMode': 'fragment',
+          'responseTypes': ['id_token', 'token'],
           'nonce': null,
         })
       ],
@@ -76,6 +107,7 @@ void main() {
           'grantType': 'authorization_code',
           'codeVerifier': null,
           'responseMode': 'fragment',
+          'responseTypes': null,
           'nonce': null,
         })
       ],


### PR DESCRIPTION
Updated iOS and macOS implementations to utilize ASWebAuthenticationSession for manual implicit authorization. Added responseTypes parameter to various request and response classes, ensuring compatibility with the latest OpenID Connect specifications. Adjusted Android manifest and Gradle dependencies for improved functionality.

As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_appauth])