### PR TITLE
[various] Allow resuming pending authorization after activity recreation on Android

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -88,6 +88,7 @@ public class FlutterAppauthPlugin
   private Context applicationContext;
   private Activity mainActivity;
   private PendingOperation pendingOperation;
+  private PendingAuthorization pendingAuthorization;
   private String clientSecret;
   private boolean allowInsecureConnections;
   private AuthorizationService defaultAuthorizationService;
@@ -669,20 +670,32 @@ public class FlutterAppauthPlugin
 
   @Override
   public boolean onActivityResult(int requestCode, int resultCode, Intent intent) {
-    if (pendingOperation == null) {
-      return false;
-    }
     if (requestCode == RC_AUTH_EXCHANGE_CODE || requestCode == RC_AUTH) {
       if (intent == null) {
+        if (pendingOperation == null) {
+          return false;
+        }
         finishWithError(NULL_INTENT_ERROR_CODE, NULL_INTENT_ERROR_FORMAT, null);
-      } else {
-        final AuthorizationResponse authResponse = AuthorizationResponse.fromIntent(intent);
-        AuthorizationException ex = AuthorizationException.fromIntent(intent);
-        processAuthorizationData(authResponse, ex, requestCode == RC_AUTH_EXCHANGE_CODE);
+        return true;
       }
+      final AuthorizationResponse authResponse = AuthorizationResponse.fromIntent(intent);
+      final AuthorizationException authException = AuthorizationException.fromIntent(intent);
+      final boolean exchangeCode = requestCode == RC_AUTH_EXCHANGE_CODE;
+      if (pendingOperation == null) {
+        // The Flutter call that started this authorization flow no longer has a
+        // pending Result to complete. This happens when the host activity is killed and recreated
+        // while in the background of the browser. Stash the response so it can be retrieved
+        // later via resumePendingAuthorization() to process the authorization on the flutter side.
+        pendingAuthorization = new PendingAuthorization(authResponse, authException, exchangeCode);
+        return true;
+      }
+      processAuthorizationData(authResponse, authException, exchangeCode);
       return true;
     }
     if (requestCode == RC_END_SESSION) {
+      if (pendingOperation == null) {
+        return false;
+      }
       if (intent == null) {
         finishWithError(NULL_INTENT_ERROR_CODE, NULL_INTENT_ERROR_FORMAT, null);
       } else {
@@ -782,6 +795,22 @@ public class FlutterAppauthPlugin
     PendingOperation(String method, Result result) {
       this.method = method;
       this.result = result;
+    }
+  }
+
+  private class PendingAuthorization {
+    final AuthorizationResponse response;
+    final AuthorizationException exception;
+    final boolean exchangeCode;
+
+    PendingAuthorization(
+        AuthorizationResponse response,
+        AuthorizationException exception,
+        boolean exchangeCode
+    ) {
+      this.response = response;
+      this.exception = exception;
+      this.exchangeCode = exchangeCode;
     }
   }
 

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -52,6 +52,7 @@ public class FlutterAppauthPlugin
   private static final String AUTHORIZE_METHOD = "authorize";
   private static final String TOKEN_METHOD = "token";
   private static final String END_SESSION_METHOD = "endSession";
+  private static final String RESUME_PENDING_AUTHORIZATION_METHOD = "resumePendingAuthorization";
 
   private static final String DISCOVERY_ERROR_CODE = "discovery_failed";
   private static final String AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE =
@@ -197,6 +198,17 @@ public class FlutterAppauthPlugin
           handleEndSessionMethodCall(arguments);
         } catch (Exception ex) {
           finishWithError(END_SESSION_ERROR_CODE, ex.getLocalizedMessage(), ex);
+        }
+        break;
+      case RESUME_PENDING_AUTHORIZATION_METHOD:
+        try {
+          handleResumePendingAuthorizationMethodCall(result);
+        } catch (Exception ex) {
+          String errorCode = AUTHORIZE_ERROR_CODE;
+          if (pendingAuthorization != null && pendingAuthorization.exchangeCode ) {
+            errorCode = AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE;
+          }
+          finishWithError(errorCode, ex.getLocalizedMessage(), ex);
         }
         break;
       default:
@@ -712,6 +724,19 @@ public class FlutterAppauthPlugin
       return true;
     }
     return false;
+  }
+
+  private void handleResumePendingAuthorizationMethodCall(Result result) {
+    if (pendingAuthorization == null) {
+      result.success(null);
+      return;
+    }
+
+    final PendingAuthorization pendingAuth = pendingAuthorization;
+    pendingAuthorization = null;
+
+    checkAndSetPendingOperation(RESUME_PENDING_AUTHORIZATION_METHOD, result);
+    processAuthorizationData(pendingAuth.response, pendingAuth.exception, pendingAuth.exchangeCode);
   }
 
   private void processAuthorizationData(

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.h
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppAuth.h
@@ -33,6 +33,8 @@ static NSString *const AUTHORIZE_AND_EXCHANGE_CODE_METHOD =
     @"authorizeAndExchangeCode";
 static NSString *const TOKEN_METHOD = @"token";
 static NSString *const END_SESSION_METHOD = @"endSession";
+static NSString *const RESUME_PENDING_AUTHORIZATION_METHOD =
+    @"resumePendingAuthorization";
 static NSString *const AUTHORIZE_ERROR_CODE = @"authorize_failed";
 static NSString *const AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE =
     @"authorize_and_exchange_code_failed";

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
@@ -164,6 +164,10 @@ AppAuthAuthorization *authorization;
     [self handleTokenMethodCall:[call arguments] result:result];
   } else if ([END_SESSION_METHOD isEqualToString:call.method]) {
     [self handleEndSessionMethodCall:[call arguments] result:result];
+  } else if ([RESUME_PENDING_AUTHORIZATION_METHOD isEqualToString:call.method]) {
+    // Only Android can lose a pending authorization result to Activity
+    // recreation; there is never anything to resume here.
+    result(nil);
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/flutter_appauth/lib/flutter_appauth.dart
+++ b/flutter_appauth/lib/flutter_appauth.dart
@@ -1,6 +1,9 @@
 export 'package:flutter_appauth_platform_interface/flutter_appauth_platform_interface.dart'
     show
         AuthorizationRequest,
+        AuthorizationResumeResponse,
+        AuthorizationResumeResponseAuthorize,
+        AuthorizationResumeResponseToken,
         AuthorizationResponse,
         AuthorizationServiceConfiguration,
         AuthorizationTokenRequest,

--- a/flutter_appauth/lib/src/flutter_appauth.dart
+++ b/flutter_appauth/lib/src/flutter_appauth.dart
@@ -32,4 +32,16 @@ class FlutterAppAuth {
   Future<EndSessionResponse> endSession(EndSessionRequest request) {
     return FlutterAppAuthPlatform.instance.endSession(request);
   }
+
+  /// On Android, attempts to resume an authorization result that the native
+  /// platform received while no Dart call is awaiting it. This can happen
+  /// when the host Activity is recreated (e.g. by the OS reclaiming memory)
+  /// while the authorization browser is in the foreground.
+  /// Call this after the app has reinitialized to
+  /// retrieve that result. Returns null if there is nothing pending.
+  ///
+  /// Always returns null on other platforms. 
+  Future<AuthorizationResumeResponse?> resumePendingAuthorization() {
+    return FlutterAppAuthPlatform.instance.resumePendingAuthorization();
+  }
 }

--- a/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
+++ b/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
@@ -163,6 +163,10 @@ AppAuthAuthorization *authorization;
     [self handleTokenMethodCall:[call arguments] result:result];
   } else if ([END_SESSION_METHOD isEqualToString:call.method]) {
     [self handleEndSessionMethodCall:[call arguments] result:result];
+  } else if ([RESUME_PENDING_AUTHORIZATION_METHOD isEqualToString:call.method]) {
+    // Only Android can lose a pending authorization result to Activity
+    // recreation; there is never anything to resume here.
+    result(nil);
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/flutter_appauth_platform_interface/lib/flutter_appauth_platform_interface.dart
+++ b/flutter_appauth_platform_interface/lib/flutter_appauth_platform_interface.dart
@@ -1,4 +1,5 @@
 export 'src/authorization_request.dart';
+export 'src/authorization_resume_response.dart';
 export 'src/authorization_response.dart';
 export 'src/authorization_service_configuration.dart';
 export 'src/authorization_token_request.dart';

--- a/flutter_appauth_platform_interface/lib/src/authorization_resume_response.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_resume_response.dart
@@ -1,0 +1,32 @@
+import 'authorization_response.dart';
+import 'authorization_token_response.dart';
+
+/// The result of resuming a pending authorization result that the native
+/// platform received while no Dart call was awaiting it.
+///
+/// Depending on whether the original authorization flow was started with
+/// `authorize()` or `authorizeAndExchangeCode()`, this is either
+/// [AuthorizationResumeResponseAuthorize] or
+/// [AuthorizationResumeResponseToken].
+sealed class AuthorizationResumeResponse {
+  const factory AuthorizationResumeResponse.authorize(
+    AuthorizationResponse response,
+  ) = AuthorizationResumeResponseAuthorize;
+
+  const factory AuthorizationResumeResponse.token(
+    AuthorizationTokenResponse response,
+  ) = AuthorizationResumeResponseToken;
+}
+
+class AuthorizationResumeResponseAuthorize 
+  implements AuthorizationResumeResponse {
+  final AuthorizationResponse response;
+
+  const AuthorizationResumeResponseAuthorize(this.response);
+}
+
+class AuthorizationResumeResponseToken implements AuthorizationResumeResponse {
+  final AuthorizationTokenResponse response;
+
+  const AuthorizationResumeResponseToken(this.response);
+}

--- a/flutter_appauth_platform_interface/lib/src/flutter_appauth_platform.dart
+++ b/flutter_appauth_platform_interface/lib/src/flutter_appauth_platform.dart
@@ -1,6 +1,7 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'authorization_request.dart';
+import 'authorization_resume_response.dart';
 import 'authorization_response.dart';
 import 'authorization_token_request.dart';
 import 'authorization_token_response.dart';
@@ -61,5 +62,18 @@ abstract class FlutterAppAuthPlatform extends PlatformInterface {
   /// end session endpoint per the [RP-initiated logout spec](https://openid.net/specs/openid-connect-rpinitiated-1_0.html).
   Future<EndSessionResponse> endSession(EndSessionRequest request) {
     throw UnimplementedError('endSession() has not been implemented');
+  }
+
+  /// On Android, attempts to resume an authorization result that the native
+  /// platform received while no Dart call is awaiting it. This can happen
+  /// when the host Activity is recreated (e.g. by the OS reclaiming memory)
+  /// while the authorization browser is in the foreground.
+  /// Call this after the app has reinitialized to
+  /// retrieve that result. Returns null if there is nothing pending.
+  ///
+  /// Always returns null on other platforms. 
+  Future<AuthorizationResumeResponse?> resumePendingAuthorization() {
+    throw UnimplementedError(
+        'resumePendingAuthorization() has not been implemented');
   }
 }

--- a/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
@@ -3,6 +3,7 @@ import 'package:flutter_appauth_platform_interface/src/end_session_request.dart'
 import 'package:flutter_appauth_platform_interface/src/end_session_response.dart';
 
 import 'authorization_request.dart';
+import 'authorization_resume_response.dart';
 import 'authorization_response.dart';
 import 'authorization_token_request.dart';
 import 'authorization_token_response.dart';
@@ -23,13 +24,7 @@ class MethodChannelFlutterAppAuth extends FlutterAppAuthPlatform {
       request.toMap(),
     );
 
-    return AuthorizationResponse(
-      authorizationCode: result['authorizationCode'],
-      codeVerifier: result['codeVerifier'],
-      nonce: result['nonce'],
-      authorizationAdditionalParameters:
-          result['authorizationAdditionalParameters']?.cast<String, dynamic>(),
-    );
+    return authorizationResponseFromResultMap(result);
   }
 
   @override
@@ -40,18 +35,7 @@ class MethodChannelFlutterAppAuth extends FlutterAppAuthPlatform {
       request.toMap(),
     );
 
-    return AuthorizationTokenResponse(
-        result['accessToken'],
-        result['refreshToken'],
-        result['accessTokenExpirationTime'] == null
-            ? null
-            : DateTime.fromMillisecondsSinceEpoch(
-                result['accessTokenExpirationTime'].toInt()),
-        result['idToken'],
-        result['tokenType'],
-        result['scopes']?.cast<String>(),
-        result['authorizationAdditionalParameters']?.cast<String, dynamic>(),
-        result['tokenAdditionalParameters']?.cast<String, dynamic>());
+    return authorizationTokenResponseFromResultMap(result);
   }
 
   @override
@@ -84,47 +68,80 @@ class MethodChannelFlutterAppAuth extends FlutterAppAuthPlatform {
     return EndSessionResponse(result['state']);
   }
 
+  @override
+  Future<AuthorizationResumeResponse?> resumePendingAuthorization() async {
+    Map<dynamic, dynamic>? result;
+    try {
+      result = await _channel.invokeMethod<Map<dynamic, dynamic>>(
+        'resumePendingAuthorization',
+      );
+    } on PlatformException catch (e) {
+      _mapAndThrowPlatformException(e);
+    }
+
+    if (result == null) {
+      return null;
+    }
+
+    if (result.containsKey('accessToken')) {
+      return AuthorizationResumeResponse.token(
+        authorizationTokenResponseFromResultMap(result),
+      );
+    }
+
+    return AuthorizationResumeResponse.authorize(
+      authorizationResponseFromResultMap(result),
+    );
+  }
+
   Future<Map<dynamic, dynamic>> invokeMethod(
       String method, dynamic arguments) async {
     try {
       return (await _channel.invokeMethod<Map<dynamic, dynamic>>(
           method, arguments))!;
     } on PlatformException catch (e) {
-      if (e.details == null) {
-        rethrow;
-      }
-      final Map<String?, String?>? errorDetails = _extractErrorDetails(
-        e.details,
+      _mapAndThrowPlatformException(e);
+    }
+  }
+
+  /// Maps a raw [PlatformException] from the method channel into one of the
+  /// package's typed exceptions and throws it, or rethrows [e] unchanged if
+  /// it doesn't carry the expected error details.
+  Never _mapAndThrowPlatformException(PlatformException e) {
+    if (e.details == null) {
+      throw e;
+    }
+    final Map<String?, String?>? errorDetails = _extractErrorDetails(
+      e.details,
+    );
+    if (errorDetails == null) {
+      throw e;
+    }
+
+    // Ensures that the PlatformException remains the same as before the
+    // introduction of custom exception handling so as to not break existing
+    // usages.
+    final dynamic legacyErrorDetails =
+        errorDetails['legacy_error_details'] ?? errorDetails;
+    final FlutterAppAuthPlatformErrorDetails parsedDetails =
+        FlutterAppAuthPlatformErrorDetails.fromMap(errorDetails);
+
+    if (errorDetails['user_did_cancel']?.toLowerCase().trim() == 'true') {
+      throw FlutterAppAuthUserCancelledException(
+        code: e.code,
+        message: e.message,
+        stacktrace: e.stacktrace,
+        legacyDetails: legacyErrorDetails,
+        platformErrorDetails: parsedDetails,
       );
-      if (errorDetails == null) {
-        rethrow;
-      }
-
-      // Ensures that the PlatformException remains the same as before the
-      // introduction of custom exception handling so as to not break existing
-      // usages.
-      final dynamic legacyErrorDetails =
-          errorDetails['legacy_error_details'] ?? errorDetails;
-      final FlutterAppAuthPlatformErrorDetails parsedDetails =
-          FlutterAppAuthPlatformErrorDetails.fromMap(errorDetails);
-
-      if (errorDetails['user_did_cancel']?.toLowerCase().trim() == 'true') {
-        throw FlutterAppAuthUserCancelledException(
-          code: e.code,
-          message: e.message,
-          stacktrace: e.stacktrace,
-          legacyDetails: legacyErrorDetails,
-          platformErrorDetails: parsedDetails,
-        );
-      } else {
-        throw FlutterAppAuthPlatformException(
-          code: e.code,
-          message: e.message,
-          stacktrace: e.stacktrace,
-          legacyDetails: legacyErrorDetails,
-          platformErrorDetails: parsedDetails,
-        );
-      }
+    } else {
+      throw FlutterAppAuthPlatformException(
+        code: e.code,
+        message: e.message,
+        stacktrace: e.stacktrace,
+        legacyDetails: legacyErrorDetails,
+        platformErrorDetails: parsedDetails,
+      );
     }
   }
 

--- a/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
@@ -1,7 +1,9 @@
 import 'authorization_parameters.dart';
 import 'authorization_request.dart';
+import 'authorization_response.dart';
 import 'authorization_service_configuration.dart';
 import 'authorization_token_request.dart';
+import 'authorization_token_response.dart';
 import 'common_request_details.dart';
 import 'end_session_request.dart';
 import 'grant_type.dart';
@@ -102,4 +104,35 @@ Map<String, Object?> _convertAuthorizationParametersToMap(
     'externalUserAgent': authorizationParameters.externalUserAgent?.index,
     'responseMode': authorizationParameters.responseMode,
   };
+}
+
+/// Builds an [AuthorizationResponse] from the raw method channel result of an
+/// `authorize` call.
+AuthorizationResponse authorizationResponseFromResultMap(
+    Map<dynamic, dynamic> result) {
+  return AuthorizationResponse(
+    authorizationCode: result['authorizationCode'],
+    codeVerifier: result['codeVerifier'],
+    nonce: result['nonce'],
+    authorizationAdditionalParameters:
+        result['authorizationAdditionalParameters']?.cast<String, dynamic>(),
+  );
+}
+
+/// Builds an [AuthorizationTokenResponse] from the raw method channel result
+/// of an `authorizeAndExchangeCode` call.
+AuthorizationTokenResponse authorizationTokenResponseFromResultMap(
+    Map<dynamic, dynamic> result) {
+  return AuthorizationTokenResponse(
+      result['accessToken'],
+      result['refreshToken'],
+      result['accessTokenExpirationTime'] == null
+          ? null
+          : DateTime.fromMillisecondsSinceEpoch(
+              result['accessTokenExpirationTime'].toInt()),
+      result['idToken'],
+      result['tokenType'],
+      result['scopes']?.cast<String>(),
+      result['authorizationAdditionalParameters']?.cast<String, dynamic>(),
+      result['tokenAdditionalParameters']?.cast<String, dynamic>());
 }

--- a/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
+++ b/flutter_appauth_platform_interface/test/method_channel_flutter_appauth_test.dart
@@ -190,4 +190,92 @@ void main() {
       })
     ]);
   });
+
+  group('resumePendingAuthorization', () {
+    tearDown(() {
+      // Restore the default handler used by the rest of the tests.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        log.add(methodCall);
+        return <Object, Object>{};
+      });
+    });
+
+    test('returns null when nothing is pending', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        log.add(methodCall);
+        return null;
+      });
+
+      final AuthorizationResumeResponse? result =
+          await flutterAppAuth.resumePendingAuthorization();
+
+      expect(result, isNull);
+      expect(log, <Matcher>[
+        isMethodCall('resumePendingAuthorization', arguments: null)
+      ]);
+    });
+
+    test('returns an AuthorizationResponse for a resumed authorize() flow',
+        () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        log.add(methodCall);
+        return <Object, Object?>{
+          'authorizationCode': 'someAuthorizationCode',
+          'codeVerifier': 'someCodeVerifier',
+          'nonce': 'someNonce',
+          'authorizationAdditionalParameters': <String, dynamic>{},
+        };
+      });
+
+      final AuthorizationResumeResponse? result =
+          await flutterAppAuth.resumePendingAuthorization();
+
+      expect(result, isA<AuthorizationResumeResponseAuthorize>());
+      final response = (result as AuthorizationResumeResponseAuthorize)
+        .response;
+      expect(response.authorizationCode,
+          'someAuthorizationCode');
+      expect(response.codeVerifier, 'someCodeVerifier');
+      expect(response.nonce, 'someNonce');
+      expect(response.authorizationAdditionalParameters, isNotNull);
+    });
+
+    test(
+        'returns an AuthorizationTokenResponse for a resumed '
+        'authorizeAndExchangeCode() flow', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        log.add(methodCall);
+        return <Object, Object?>{
+          'accessToken': 'someAccessToken',
+          'refreshToken': 'someRefreshToken',
+          'accessTokenExpirationTime': 1784239200000,
+          'idToken': 'someIdToken',
+          'tokenType': 'bearer',
+          'scopes': <String>['someScope'],
+          'authorizationAdditionalParameters': <String, dynamic>{},
+          'tokenAdditionalParameters': <String, dynamic>{},
+        };
+      });
+
+      final AuthorizationResumeResponse? result =
+          await flutterAppAuth.resumePendingAuthorization();
+
+      expect(result, isA<AuthorizationResumeResponseToken>());
+      final response = (result as AuthorizationResumeResponseToken).response;
+      expect(
+          response.accessToken, 'someAccessToken');
+      expect(
+          response.refreshToken, 'someRefreshToken');
+      expect(response.accessTokenExpirationDateTime, DateTime(2026, 7, 17));
+      expect(response.idToken, 'someIdToken');
+      expect(response.tokenType, 'bearer');
+      expect(response.scopes, ["someScope"]);
+      expect(response.authorizationAdditionalParameters, isNotNull);
+      expect(response.tokenAdditionalParameters, isNotNull);
+    });
+  });
 }


### PR DESCRIPTION
We have encountered an issue where the auth response is not handled after returning from the browser back to the app. This happens when the app's Activity is killed by Android (e.g. for clearing up memory). This PR adds a resumePendingAuthorization() method that allows the app to get the "missed" auth response after reinitialising itself.

### Steps to reproduce:
1. Enable "Don't keep activities" in Android developer settings.
2. Start auth flow.
3. Complete authentication.

=>  Browser closes, but app doesn't receive the auth response.

### Behaviour with fix:
1. Browser auth flow started
2. Activity killed in background
3. Browser flow finishes
4. Activity is recreated and flutter reinitialized
5. App calls resumePendingAuthorization() and receives response
6. User logged in
