### PR TITLE
[flutter_appauth] Improve SFSafariViewController user cancellation handling

### DIFF
--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/OIDExternalUserAgentIOSSafariViewController.m
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/OIDExternalUserAgentIOSSafariViewController.m
@@ -35,7 +35,8 @@ static id<OIDSafariViewControllerFactory> __nullable
 @end
 
 @interface OIDExternalUserAgentIOSSafariViewController () <
-    SFSafariViewControllerDelegate>
+    SFSafariViewControllerDelegate,
+    UIAdaptivePresentationControllerDelegate>
 @end
 
 @implementation OIDExternalUserAgentIOSSafariViewController {
@@ -93,6 +94,7 @@ static id<OIDSafariViewControllerFactory> __nullable
         safariViewControllerFactory] safariViewControllerWithURL:requestURL];
     safariVC.delegate = self;
     safariVC.modalPresentationStyle = UIModalPresentationFormSheet;
+    safariVC.presentationController.delegate = self;
     _safariVC = safariVC;
     [_presentingViewController presentViewController:safariVC
                                             animated:YES
@@ -168,6 +170,27 @@ static id<OIDSafariViewControllerFactory> __nullable
       underlyingError:nil
           description:nil];
   [session failExternalUserAgentFlowWithError:error];
+}
+
+#pragma mark - UIAdaptivePresentationControllerDelegate
+
+- (void)presentationControllerDidDismiss:
+    (UIPresentationController *)presentationController {
+    if (presentationController.presentedViewController != _safariVC) {
+      // Ignore this call if the safari view controller do not match.
+      return;
+    }
+    if (!_externalUserAgentFlowInProgress) {
+      // Ignore this call if there is no authorization flow in progress.
+      return;
+    }
+    id<OIDExternalUserAgentSession> session = _session;
+    [self cleanUp];
+    NSError *error = [OIDErrorUtilities
+          errorWithCode:OIDErrorCodeProgramCanceledAuthorizationFlow
+        underlyingError:nil
+            description:nil];
+    [session failExternalUserAgentFlowWithError:error];
 }
 
 @end

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/OIDExternalUserAgentIOSSafariViewController.m
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/OIDExternalUserAgentIOSSafariViewController.m
@@ -92,6 +92,11 @@ static id<OIDSafariViewControllerFactory> __nullable
   if (@available(iOS 9.0, *)) {
     SFSafariViewController *safariVC = [[[self class]
         safariViewControllerFactory] safariViewControllerWithURL:requestURL];
+
+    if (@available(iOS 11.0, *)) {
+        safariVC.dismissButtonStyle = SFSafariViewControllerDismissButtonStyleCancel;
+    }
+
     safariVC.delegate = self;
     safariVC.modalPresentationStyle = UIModalPresentationFormSheet;
     safariVC.presentationController.delegate = self;

--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/OIDExternalUserAgentIOSSafariViewController.m
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/OIDExternalUserAgentIOSSafariViewController.m
@@ -171,7 +171,7 @@ static id<OIDSafariViewControllerFactory> __nullable
   id<OIDExternalUserAgentSession> session = _session;
   [self cleanUp];
   NSError *error = [OIDErrorUtilities
-        errorWithCode:OIDErrorCodeProgramCanceledAuthorizationFlow
+        errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
       underlyingError:nil
           description:nil];
   [session failExternalUserAgentFlowWithError:error];
@@ -192,7 +192,7 @@ static id<OIDSafariViewControllerFactory> __nullable
     id<OIDExternalUserAgentSession> session = _session;
     [self cleanUp];
     NSError *error = [OIDErrorUtilities
-          errorWithCode:OIDErrorCodeProgramCanceledAuthorizationFlow
+          errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
         underlyingError:nil
             description:nil];
     [session failExternalUserAgentFlowWithError:error];


### PR DESCRIPTION
# Summary

Handle interactive dismissal of SFSafariViewController to ensure the external user agent flow is completed correctly when the controller is dismissed with a swipe gesture.

# Changes

* Added `UIAdaptivePresentationControllerDelegate` conformance to `OIDExternalUserAgentIOSSafariViewController`.
* Registered the `UIPresentationController` delegate for `SFSafariViewController`.
* Implemented `presentationControllerDidDismiss:`.
* Changed the `dismissButtonStyle` to match the `ASWebAuthenticationSession` behavior.
* Reused the existing cancellation logic so both tapping **Cancel** and interactive dismissal follow the same code path.
* Changed the cancellation error reported by `SFSafariViewController` dismissal to `OIDErrorCodeUserCanceledAuthorizationFlow` to align with user-initiated cancellation semantics.


Fixes #649 