### PR TITLE
[flutter_appauth] macOS: also resume the authorization flow from the app lifecycle

### DIFF
--- a/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/include/flutter_appauth/FlutterAppauthPlugin.h
+++ b/flutter_appauth/ios/flutter_appauth/Sources/flutter_appauth/include/flutter_appauth/FlutterAppauthPlugin.h
@@ -6,6 +6,13 @@
 #import <Flutter/Flutter.h>
 #endif
 
+#if TARGET_OS_OSX
+@interface FlutterAppauthPlugin
+    : NSObject <FlutterPlugin, FlutterAppLifecycleDelegate>
+
+@end
+#else
 @interface FlutterAppauthPlugin : NSObject <FlutterPlugin>
 
 @end
+#endif

--- a/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
+++ b/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/FlutterAppauthPlugin.m
@@ -142,6 +142,23 @@ AppAuthAuthorization *authorization;
                                                   withReplyEvent:)
                        forEventClass:kInternetEventClass
                           andEventID:kAEGetURL];
+
+  // Also receive URLs through the Flutter application lifecycle.
+  //
+  // `setEventHandler:` above REPLACES any existing handler for kAEGetURL, and
+  // AppKit installs its own — the one that drives `application:openURLs:` —
+  // during `finishLaunching`, which happens after plugin registration. So in
+  // any host app whose delegate implements `application:openURLs:` (i.e. any
+  // app with deep links) AppKit wins and `handleGetURLEvent:` never fires.
+  // The pending authorization is then never resumed for a redirect delivered
+  // from outside the app's own browser session, and the login hangs with no
+  // error.
+  //
+  // Registering as an application delegate makes `FlutterAppDelegate` forward
+  // `application:openURLs:` here too, so the resume happens on whichever path
+  // actually delivers the URL. Both are safe together: the flow is cleared
+  // after the first successful resume.
+  [registrar addApplicationDelegate:instance];
 #else
   authorization = [[AppAuthIOSAuthorization alloc] init];
 
@@ -507,6 +524,24 @@ AppAuthAuthorization *authorization;
   NSURL *URL = [NSURL URLWithString:URLString];
   [_currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:URL];
   _currentAuthorizationFlow = nil;
+}
+
+/// The `FlutterAppLifecycleDelegate` counterpart of `handleGetURLEvent:`, for
+/// hosts where AppKit owns the kAEGetURL handler.
+///
+/// Returns YES only when a pending flow accepted the URL, so unrelated deep
+/// links keep flowing to the host app's own handling.
+- (BOOL)handleOpenURLs:(NSArray<NSURL *> *)urls {
+  if (_currentAuthorizationFlow == nil) {
+    return NO;
+  }
+  for (NSURL *url in urls) {
+    if ([_currentAuthorizationFlow resumeExternalUserAgentFlowWithURL:url]) {
+      _currentAuthorizationFlow = nil;
+      return YES;
+    }
+  }
+  return NO;
 }
 #endif
 


### PR DESCRIPTION
On macOS the plugin installs a `kAEGetURL` Apple Event handler so an authorization redirect delivered from outside the app's own browser session can resume the pending flow. In a large class of host apps that handler never runs.

`NSAppleEventManager setEventHandler:` **replaces** any existing handler for the event. AppKit installs its own during `finishLaunching` — the one that drives `application:openURLs:` — and plugin registration happens earlier, during nib loading. So AppKit's registration wins and `handleGetURLEvent:` is silently dead in **any app whose delegate implements `application:openURLs:`**, which is any app with deep links.

The symptom is a login that hangs with no error and no cancellation: the redirect reaches the host app, the plugin never sees it, and the pending `OIDExternalUserAgentSession` is never resumed. It shows up with flows whose redirect legitimately returns through a different browser — an emailed magic link, where the user opens the link from their mail client.

**The change:** also register the plugin with `addApplicationDelegate:` and implement `handleOpenURLs:`, so the resume happens on whichever path actually delivers the URL. The two paths are safe together — the flow is cleared after the first successful resume, and `handleOpenURLs:` returns `YES` only when a pending flow accepted the URL, leaving unrelated deep links to the host app. The macOS header declares `FlutterAppLifecycleDelegate` conformance, which `addApplicationDelegate:` requires.

**Verified** on macOS against a Keycloak realm: without this the flow hangs indefinitely; with it the authorization completes normally. iOS already registers via `addApplicationDelegate:` and is untouched by this change.