### PR TITLE
[flutter_appauth] Fix macOS build failure caused by PrivacyInfo.xcprivacy symlink

### DIFF
--- a/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/PrivacyInfo.xcprivacy
+++ b/flutter_appauth/macos/flutter_appauth/Sources/flutter_appauth/PrivacyInfo.xcprivacy
@@ -1,1 +1,14 @@
-../../../../ios/flutter_appauth/Sources/flutter_appauth/PrivacyInfo.xcprivacy
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
Replace the PrivacyInfo.xcprivacy symlink with a regular file to fix the macOS build failure during the CpResource phase.