### PR TITLE
Update iOS version 12 to 13 for spm in Package.swift

### DIFF
--- a/flutter_appauth/ios/flutter_appauth/Package.swift
+++ b/flutter_appauth/ios/flutter_appauth/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "flutter_appauth",
     platforms: [
-        .iOS("12.0")
+        .iOS("13.0")
     ],
     products: [
         .library(name: "flutter-appauth", targets: ["flutter_appauth"])


### PR DESCRIPTION
[flutter_appauth]
Fix unable to compile app with error:
`The package product 'FlutterFramework' requires minimum platform version 13.0 for the iOS platform, but this target supports 12.0`
when using Swift Package Manager